### PR TITLE
Implement drink reviews

### DIFF
--- a/next-server/prisma/schema.prisma
+++ b/next-server/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   posts           Post[]
   postComments    PostComment[]
   blogs           Blog[]
+  drinkReviews   DrinkReview[]
   messageReadStatus MessageReadStatus[]
 
   conversationsIds String[]      @db.ObjectId
@@ -164,7 +165,18 @@ model PostComment {
   text    String
   postId String? @db.ObjectId
   post   Post? @relation(fields: [postId], references: [id])
-  writerEmail String? 
+  writerEmail String?
   writer    User?  @relation(fields: [writerEmail], references: [email], onDelete: Cascade)
   createdAt DateTime @default(now())
+}
+
+model DrinkReview {
+  id        String  @id   @map("_id")  @default(auto())  @db.ObjectId
+  drinkSlug String
+  text      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  authorEmail String?
+  author      User? @relation(fields: [authorEmail], references: [email])
 }

--- a/next-server/src/app/(main)/(home)/drinks/[name]/page.tsx
+++ b/next-server/src/app/(main)/(home)/drinks/[name]/page.tsx
@@ -4,10 +4,14 @@ import { useRouter } from 'next/navigation';
 import drinksDetailData from '@/src/app/data/drinksDetail';
 import clsx from 'clsx';
 import Image from 'next/image';
-import {  motion } from 'framer-motion';
+import { motion } from 'framer-motion';
+import { useSession } from 'next-auth/react';
+import FormReview from '@/src/app/components/FormReview';
+import Reviews from '@/src/app/components/Reviews';
 
-const DrinksPage = ({params } : { params: { name: string } }) => { 
+const DrinksPage = ({params } : { params: { name: string } }) => {
     const router = useRouter();
+    const { data: session } = useSession();
 
     const { name } = params;
 
@@ -122,7 +126,9 @@ const DrinksPage = ({params } : { params: { name: string } }) => {
                     />
                 </motion.div>
             </div>
-        }         
+        }
+        <FormReview slug={name} user={session?.user!} />
+        <Reviews slug={name} />
     </div>
   );
 };

--- a/next-server/src/app/api/drinks/reviews/[slug]/route.ts
+++ b/next-server/src/app/api/drinks/reviews/[slug]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from '../../../../../../prisma/db';
+import { getCurrentUser } from '@/src/app/lib/session';
+
+interface IParams {
+    slug?: string;
+}
+
+export async function GET(
+    req: NextRequest,
+    { params }: { params: IParams }
+) {
+    try {
+        const { slug } = params;
+        const limit = 20;
+        const cursor = req.nextUrl.searchParams.get('cursor') || null;
+
+        const reviewsCount = await prisma.drinkReview.count({
+            where: { drinkSlug: slug }
+        });
+
+        const reviews = await prisma.drinkReview.findMany({
+            where: { drinkSlug: slug },
+            orderBy: { createdAt: 'desc' },
+            ...(cursor && { cursor: { id: cursor } }),
+            take: limit,
+            skip: cursor ? 1 : 0,
+            select: {
+                id: true,
+                text: true,
+                authorEmail: true,
+                createdAt: true,
+                updatedAt: true,
+                drinkSlug: true,
+                author: {
+                    select: {
+                        id: true,
+                        name: true,
+                        email: true,
+                        image: true,
+                        profileImage: true,
+                        role: true,
+                    }
+                },
+            }
+        });
+
+        return NextResponse.json({ reviews, reviewsCount }, { status: 200 });
+    } catch(error) {
+        return NextResponse.json({ message: '리뷰를 불러오지 못했습니다.' }, { status: 500 });
+    }
+}
+
+export async function POST(
+    req: NextRequest,
+    { params }: { params: IParams }
+) {
+    const { slug } = params;
+    const user = await getCurrentUser();
+
+    try {
+        if (!user?.email) {
+            return NextResponse.json({ message: '로그인 후에 리뷰를 작성할 수 있습니다.' }, { status: 401 });
+        }
+
+        const { text } = await req.json();
+        const newReview = await prisma.drinkReview.create({
+            data: {
+                drinkSlug: slug!,
+                text,
+                authorEmail: user.email,
+            }
+        });
+        return NextResponse.json({ newReview }, { status: 200 });
+    } catch(error) {
+        return NextResponse.json({ message: 'Something went wrong!' }, { status: 500 });
+    }
+}

--- a/next-server/src/app/components/FormReview.tsx
+++ b/next-server/src/app/components/FormReview.tsx
@@ -1,0 +1,110 @@
+'use client';
+import TextareaAutosize from 'react-textarea-autosize';
+import React, { useRef, useState, FormEvent } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createDrinkReviews } from '@/src/app/lib/createDrinkReviews';
+import { DrinkReviewsDataProps, DrinkReviewType } from '@/src/app/types/drink';
+
+type FormReviewProps = {
+    slug: string;
+    user: {
+        role?: string;
+        id: string;
+        name?: string | null | undefined;
+        email?: string | null | undefined;
+        image?: string | null | undefined;
+    };
+};
+
+const FormReview = ({ slug, user } : FormReviewProps) => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const [review, setReview] = useState<string>('');
+    const [stateReview, setStateReview] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const queryClient = useQueryClient();
+
+    const { mutate: createDrinkReviewsMutation } = useMutation({
+        mutationFn: createDrinkReviews,
+        onSuccess: (newData) => {
+            setReview('');
+            queryClient.setQueriesData({ queryKey: ['drinkReviews', slug] },
+                (oldData: DrinkReviewsDataProps | undefined): DrinkReviewsDataProps => {
+                    const newReviewData = newData.newReview;
+                    newReviewData.author = user;
+
+                    if (!oldData || oldData.pages.length === 0) {
+                        return {
+                            pages: [[
+                                { reviews: [newReviewData] },
+                                { reviewsCount: 1 }
+                            ]],
+                            pageParams: [undefined],
+                        };
+                    }
+
+                    const currentPage = oldData.pages[0];
+                    const reviewsObj = currentPage.find((p) => 'reviews' in p) as { reviews: DrinkReviewType[] };
+                    const countObj = currentPage.find((p) => 'reviewsCount' in p) as { reviewsCount: number };
+
+                    const updatedPage: [ { reviews: DrinkReviewType[] }, { reviewsCount: number } ] = [
+                        { reviews: [newReviewData, ...reviewsObj.reviews] },
+                        { reviewsCount: countObj.reviewsCount + 1 }
+                    ];
+
+                    return {
+                        ...oldData,
+                        pages: [updatedPage, ...oldData.pages.slice(1)],
+                    };
+                }
+            );
+        },
+    });
+
+    const onFocus = () => {
+        if(!user.email) return;
+        setStateReview(true);
+    };
+
+    const handleSubmitReview = (e: FormEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        if(review.trim() === '') {
+            textareaRef.current?.focus();
+            return alert('리뷰를 입력해주세요.');
+        }
+        if (isSubmitting) return;
+        setIsSubmitting(true);
+        createDrinkReviewsMutation(
+            { slug, text: review },
+            {
+                onSettled: () => {
+                    setIsSubmitting(false);
+                }
+            }
+        );
+    };
+
+    return (
+        <div className='my-4'>
+            <TextareaAutosize
+                ref={textareaRef}
+                disabled={user?.email ? false : true}
+                placeholder={user?.email ? '리뷰를 입력해주세요.' : '로그인 후에 리뷰를 작성할 수 있습니다.'}
+                value={review}
+                onChange={e => setReview(e.target.value)}
+                onFocus={onFocus}
+                className='w-full p-2 box-border border-solid border-b-[1px]'
+            />
+            {stateReview && (
+                <button
+                    onClick={handleSubmitReview}
+                    type='submit'
+                    className='bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 mt-2 rounded-md'
+                >
+                    {isSubmitting ? '등록 중' : '리뷰'}
+                </button>
+            )}
+        </div>
+    );
+};
+
+export default FormReview;

--- a/next-server/src/app/components/Reviews.tsx
+++ b/next-server/src/app/components/Reviews.tsx
@@ -1,0 +1,113 @@
+'use client';
+import dayjs from '@/src/app/lib/day';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { PiUserCircleFill } from 'react-icons/pi';
+import { getDrinkReviews } from '@/src/app/lib/getDrinkReviews';
+import { Fragment, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import { DrinkReviewType } from '@/src/app/types/drink';
+import CommentSkeleton from './skeleton/CommentSkeleton';
+import CircularProgress from './CircularProgress';
+import FallbackNextImage from './FallbackNextImage';
+import DOMPurify from 'dompurify';
+
+type ReviewsProps = {
+    slug: string;
+};
+
+const Reviews = ({ slug } : ReviewsProps) => {
+    const {
+        data,
+        status,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery({
+        queryKey: ['drinkReviews', slug],
+        queryFn: getDrinkReviews,
+        initialPageParam: '',
+        getNextPageParam: (lastPage) => {
+            if (!lastPage) return undefined;
+            const reviewsPage = lastPage.find((item) => 'reviews' in item) as { reviews: { id: string }[] } | undefined;
+            if (!reviewsPage || !reviewsPage.reviews.length) return undefined;
+            const lastReviewId = reviewsPage.reviews.at(-1)?.id;
+            return lastReviewId || undefined;
+        }
+    });
+
+    const { ref, inView } = useInView({ threshold: 0.2, delay: 100 });
+
+    useEffect(() => {
+        if (inView && hasNextPage) {
+            fetchNextPage();
+        }
+    }, [inView]);
+
+    return (
+        <>
+            {data?.pages[0]?.flat().map((page, i) => (
+                <Fragment key={i}>
+                    {Object.keys(page)[0] === 'reviewsCount' && (
+                        <h4>리뷰 {page.reviewsCount}개</h4>
+                    )}
+                </Fragment>
+            ))}
+            {status === 'pending' ? (
+                <div className='flex flex-col gap-3'>
+                    <CommentSkeleton />
+                    <CommentSkeleton />
+                    <CommentSkeleton />
+                    <CommentSkeleton />
+                </div>
+            ) : (
+                <>
+                    <ul className='mt-2'>
+                        {data?.pages?.flat().map((page, i) => (
+                            <li key={i}>
+                                {page?.reviews && page.reviews.length > 0 && Object.keys(page)[0] === 'reviews' &&
+                                    page.reviews?.map((review: DrinkReviewType) => (
+                                        <div key={review.id} className='flex flex-row gap-3 py-1'>
+                                            <span className='shrink-0 overflow-hidden relative w-10 h-10 mt-1 rounded-full'>
+                                                {review.author?.image ? (
+                                                    <FallbackNextImage
+                                                        src={review.author?.image}
+                                                        alt={`${review.author?.name} 이미지`}
+                                                        fill
+                                                        className='object-cover'
+                                                        unoptimized={false}
+                                                    />
+                                                ) : (
+                                                    <PiUserCircleFill className='w-full h-full' />
+                                                )}
+                                            </span>
+                                            <div>
+                                                <div>
+                                                    <span className='break-all mr-2'>
+                                                        {review.author?.name}
+                                                    </span>
+                                                    <span className='text-gray-400'>
+                                                        {dayjs(review.createdAt).fromNow()}
+                                                    </span>
+                                                </div>
+                                                <pre
+                                                    className='whitespace-pre-wrap'
+                                                    dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(review?.text || '') }}
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            )}
+            <div ref={ref}>
+                {isFetchingNextPage && (
+                    <CircularProgress aria-label='로딩중' />
+                )}
+            </div>
+        </>
+    );
+};
+
+export default Reviews;

--- a/next-server/src/app/lib/createDrinkReviews.ts
+++ b/next-server/src/app/lib/createDrinkReviews.ts
@@ -1,0 +1,16 @@
+interface Props {
+    slug: string;
+    text: string;
+}
+
+export const createDrinkReviews = async ({ slug, text }: Props) => {
+    const res = await fetch(`/api/drinks/reviews/${slug}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ text }),
+    });
+
+    return res.json();
+};

--- a/next-server/src/app/lib/getDrinkReviews.ts
+++ b/next-server/src/app/lib/getDrinkReviews.ts
@@ -1,0 +1,39 @@
+import toast from "react-hot-toast";
+
+type QueryKeyProps = {
+    [key: string]: string
+};
+
+type ParamProps = {
+    queryKey: any[] | QueryKeyProps[];
+    pageParam?: any;
+};
+
+export const getDrinkReviews = async (
+    { queryKey, pageParam }: ParamProps
+) => {
+    const [_key, slug ] = queryKey;
+    const cursor = pageParam ?? null;
+
+    try {
+        const res = await fetch(`/api/drinks/reviews/${slug}?cursor=${cursor}`, {
+            next: {
+                tags: [_key]
+            },
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        const { reviews, reviewsCount } = await res.json();
+
+        if(!res.ok) {
+            toast.error('리뷰를 찾지 못했습니다.');
+        }
+
+        return [{ reviews }, { reviewsCount }];
+
+    } catch (error) {
+        console.log('error');
+    }
+};

--- a/next-server/src/app/types/drink.ts
+++ b/next-server/src/app/types/drink.ts
@@ -1,0 +1,14 @@
+import type { DrinkReview } from '@prisma/client';
+import { IUser } from '@/src/app/types/common';
+import { InfiniteData } from '@tanstack/react-query';
+
+export type DrinkReviewType = DrinkReview & {
+    author: IUser;
+};
+
+export type DrinkReviewPage = [
+    { reviews: DrinkReviewType[] },
+    { reviewsCount: number }
+];
+
+export type DrinkReviewsDataProps = InfiniteData<DrinkReviewPage>;


### PR DESCRIPTION
## Summary
- allow reviews on drinks using React Query
- add drink review API route and schema
- create FormReview and Reviews components
- load and post reviews from drink detail page
- clean up unused imports

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca4517a60832d92c120f6d2387c2c