### PR TITLE
Enable admin review editing and deletion

### DIFF
--- a/next-server/src/app/(main)/(home)/drinks/[name]/page.tsx
+++ b/next-server/src/app/(main)/(home)/drinks/[name]/page.tsx
@@ -129,7 +129,7 @@ const DrinksPage = ({params } : { params: { name: string } }) => {
         }
         <div className='md:px-6 md:py-3 px-3'>
             <FormReview slug={name} user={session?.user!} />
-            <Reviews slug={name} />
+            <Reviews slug={name} user={session?.user!} />
         </div>
     </div>
   );

--- a/next-server/src/app/api/drinks/reviews/[id]/route.ts
+++ b/next-server/src/app/api/drinks/reviews/[id]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from '@/prisma/db';
+import { getCurrentUser } from '@/src/app/lib/session';
+
+interface IParams {
+    id?: string;
+}
+
+export async function PUT(
+    req: NextRequest,
+    { params }: { params: IParams }
+) {
+    const { id } = params;
+    const user = await getCurrentUser();
+
+    try {
+        if (!user?.email) {
+            return NextResponse.json({ message: '로그인 후에 수정할 수 있습니다.' }, { status: 401 });
+        }
+
+        const review = await prisma.drinkReview.findUnique({
+            where: { id: id! },
+            select: { authorEmail: true },
+        });
+
+        if (!review) {
+            return NextResponse.json({ message: '존재하지 않는 리뷰입니다.' }, { status: 404 });
+        }
+
+        if (review.authorEmail !== user.email || user.role !== 'admin') {
+            return NextResponse.json({ message: '수정 권한이 없습니다.' }, { status: 403 });
+        }
+
+        const { text } = await req.json();
+        const updateReview = await prisma.drinkReview.update({
+            where: { id: id! },
+            data: { text, updatedAt: new Date() },
+        });
+
+        return NextResponse.json({ updateReview }, { status: 200 });
+    } catch (error) {
+        return NextResponse.json({ message: 'Something went wrong!' }, { status: 500 });
+    }
+}
+
+export async function DELETE(
+    req: NextRequest,
+    { params }: { params: IParams }
+) {
+    const { id } = params;
+    const user = await getCurrentUser();
+
+    try {
+        if (!user?.email) {
+            return NextResponse.json({ message: '로그인 후에 삭제할 수 있습니다.' }, { status: 401 });
+        }
+
+        const review = await prisma.drinkReview.findUnique({
+            where: { id: id! },
+            select: { authorEmail: true },
+        });
+
+        if (!review) {
+            return NextResponse.json({ message: '존재하지 않는 리뷰입니다.' }, { status: 404 });
+        }
+
+        if (review.authorEmail !== user.email || user.role !== 'admin') {
+            return NextResponse.json({ message: '삭제 권한이 없습니다.' }, { status: 403 });
+        }
+
+        await prisma.drinkReview.delete({
+            where: { id: id! },
+        });
+
+        return NextResponse.json({ id }, { status: 200 });
+    } catch (error) {
+        return NextResponse.json({ message: 'Something went wrong!' }, { status: 500 });
+    }
+}

--- a/next-server/src/app/lib/deleteDrinkReview.ts
+++ b/next-server/src/app/lib/deleteDrinkReview.ts
@@ -1,0 +1,10 @@
+export const deleteDrinkReview = async (id: string) => {
+    const res = await fetch(`/api/drinks/reviews/${id}`, {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+
+    return res.json();
+};

--- a/next-server/src/app/lib/updateDrinkReview.ts
+++ b/next-server/src/app/lib/updateDrinkReview.ts
@@ -1,0 +1,16 @@
+interface Props {
+    id: string;
+    text: string;
+}
+
+export const updateDrinkReview = async ({ id, text }: Props) => {
+    const res = await fetch(`/api/drinks/reviews/${id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ text }),
+    });
+
+    return res.json();
+};


### PR DESCRIPTION
## Summary
- add API for PUT/DELETE of drink reviews
- add helpers to update/delete reviews from the client
- extend Reviews component to support editing and deleting with React Query
- pass user info to Reviews on drink page

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e26afc3a0832dab4f4033451b46e9