### PR TITLE
feat: 향수 스캔 기능 — 이미지 인식·가격 비교·유사 향수 추천

### DIFF
--- a/next-server/src/app/(main)/scan/page.tsx
+++ b/next-server/src/app/(main)/scan/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+import ScanClient from '@/src/app/components/scan/ScanClient';
+
+export const metadata: Metadata = {
+  title: '향수 스캔',
+  description:
+    '카메라로 향수 사진을 찍으면 AI가 어떤 향수인지 식별하고 최저가 구매 사이트로 안내해드립니다.',
+  openGraph: {
+    title: '향수 스캔 | Scent Memories',
+    description: '사진 한 장으로 향수 식별 + 최저가 구매까지.',
+    images: [{ url: '/image/metadata/main_web.png', width: 1200, height: 627 }],
+  },
+};
+
+export default function ScanPage() {
+  return (
+    <div className="px-4 pt-8 pb-4 md:p-8 max-w-[1440px] w-full mx-auto">
+      <h2 className="text-top text-center">
+        <span className="text-gradient-scent">향수 스캔</span>
+      </h2>
+      <ScanClient />
+    </div>
+  );
+}

--- a/next-server/src/app/(main)/scan/result/[scanId]/page.tsx
+++ b/next-server/src/app/(main)/scan/result/[scanId]/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import prisma from '@/prisma/db';
+import ScanResult from '@/src/app/components/scan/ScanResult';
+
+type Props = {
+  params: Promise<{ scanId: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { scanId } = await params;
+  const scan = await prisma.scanResult.findUnique({
+    where: { id: scanId },
+    select: { brand: true, name: true },
+  });
+
+  if (!scan) {
+    return {
+      title: '스캔 결과',
+      robots: { index: false, follow: false },
+    };
+  }
+
+  return {
+    title: `${scan.brand} ${scan.name} | 스캔 결과`,
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function ScanResultPage({ params }: Props) {
+  const { scanId } = await params;
+
+  const scan = await prisma.scanResult.findUnique({
+    where: { id: scanId },
+  });
+  if (!scan) notFound();
+
+  const matched = scan.matchedSlug
+    ? await prisma.fragrance.findUnique({
+        where: { slug: scan.matchedSlug },
+        select: { slug: true, brand: true, name: true, images: true },
+      })
+    : null;
+
+  return (
+    <div className="px-4 pt-8 pb-4 md:p-8 max-w-[1440px] w-full mx-auto">
+      <div className="text-center">
+        {/* Brand — label 역할: 흐리게, 굵기 없이, 자간 넓게 */}
+        <p className="text-[13px] lg:text-sm font-normal tracking-[0.3em] uppercase text-text-secondary mb-2">
+          {scan.brand}
+        </p>
+        {/* Name — 메인 헤드라인: 브레이크포인트별 크기 조정 */}
+        <h2 className="font-josefin font-bold text-[22px] md:text-[28px] lg:text-4xl leading-tight tracking-tight">
+          <span className="text-gradient-scent">{scan.name}</span>
+        </h2>
+      </div>
+      <section className="mt-6 md:mt-10">
+        <ScanResult
+          data={{
+            scanId: scan.id,
+            brand: scan.brand,
+            name: scan.name,
+            notes: scan.notes ?? undefined,
+            description: scan.description ?? undefined,
+            imageUrl: scan.imageUrl,
+            imageWidth: scan.imageWidth,
+            imageHeight: scan.imageHeight,
+            matchedFragrance: matched,
+          }}
+        />
+      </section>
+    </div>
+  );
+}

--- a/next-server/src/app/api/scan/README.md
+++ b/next-server/src/app/api/scan/README.md
@@ -1,0 +1,113 @@
+# `/scan` — 카메라 향수 식별 & 가격 검색
+
+> 사진 → AI OCR로 brand·name 추출 → 자체 갤러리 매칭 + 네이버 쇼핑 검색 → 결과 카드.
+> **프로젝트 전반 규칙**: [next-server/CLAUDE.md](../../../../CLAUDE.md) (UI 토큰·버튼·아이콘 규칙 등 먼저 읽기)
+> **이 문서**: 코드와 함께 갱신되는 살아있는 구현 문서. 의사결정 배경은 [docs/decisions/](../../../../docs/decisions/).
+
+---
+
+## 파일 맵
+
+| 영역 | 경로 |
+|---|---|
+| 진입 페이지 | [src/app/(main)/scan/page.tsx](../../(main)/scan/page.tsx) |
+| 클라이언트 stage 머신 | [src/app/components/scan/ScanClient.tsx](../../components/scan/ScanClient.tsx) (idle → previewing → analyzing → result) |
+| 카메라 / 파일 fallback | `components/scan/CameraCapture.tsx`, `FileUploadFallback.tsx` |
+| 결과 UI | `components/scan/ScanResult.tsx`, `PriceCards.tsx` |
+| API: 분석 | [api/scan/analyze/route.ts](analyze/route.ts) — `POST /api/scan/analyze` |
+| API: 가격 | [api/scan/prices/[scanId]/route.ts](prices/[scanId]/route.ts) — `GET /api/scan/prices/:scanId` |
+| 비즈니스 로직 | [src/app/lib/scan/](../../lib/scan/) — `visionAnalyze`, `enrichInfo`, `findMatch`, `naverShopping`, `transliterate`, `rateLimit` |
+| 데이터 모델 | `ScanResult` ([prisma/schema.prisma](../../../../prisma/schema.prisma)) |
+
+---
+
+## 흐름 1 — `POST /api/scan/analyze`
+
+1. 레이트 리밋 (분당 5회/IP, in-memory) — `rateLimit.ts`
+2. multipart 수신 → Cloudinary 업로드 (unsigned preset)
+3. **Vision OCR** (`visionAnalyze.ts`): `brand/name/concentration/size` 분리 추출
+   - 1차 `detail="low"` → 결손 시 2차 `detail="high"` 재시도 (비용 최적화, [ADR-0002](../../../../docs/decisions/0002-vision-two-pass-ocr.md))
+   - `gpt-4o` 거부 시 `gpt-4o-mini` fallback
+   - 부향률을 name으로 잡으면 안전망 차단
+4. **자체 갤러리 매칭** (`findMatch.ts`): brand alias(한/영) + token 양방향 매칭
+   - 게이트: `nameRaw ≥ 50`, `total ≥ 70`
+5. **24h 캐시 조회**: 같은 `brand+name`의 이전 `ScanResult` 있으면 `description/notes/prices` 재사용
+6. description/notes 우선순위: **curated DB > 캐시 > `enrichInfo`** (gpt-4o-mini, 텍스트 LLM)
+7. `ScanResult` 저장 → `scanId` 반환 (가격은 별도 엔드포인트로 분리해 응답 지연 회피)
+
+## 흐름 2 — `GET /api/scan/prices/:scanId`
+
+가장 복잡한 모듈. 가격 절대값 대신 **다층 신호**로 정품/노이즈 분리:
+
+1. 24h `ScanResult.prices` 캐시 hit → 즉시 반환
+2. 한글 음역 (`transliterate.ts`, gpt-4o-mini) — 한글 mall title 매칭용
+3. 영문 쿼리 → 0건이면 한글 쿼리 → 병합
+4. **필터 게이트** (`naverShopping.ts` `runSingleSearch`):
+   - 샘플·디캔트·짝퉁 키워드 차단
+   - 1~15ml 소분 차단 (per-ml < ₩500도 차단 — 절대 가격 게이트 X)
+   - 옷·잡화 title 차단
+   - 향수 카테고리 매칭
+   - title이 검색어 핵심 토큰 포함
+5. **신뢰 점수 0~100**: 화이트리스트 mall +30 / 향수 카테고리 +20 / productType=2 +20 / per-ml 단가 +10~20
+6. URL 검증 (HEAD, 3s timeout, batch 5) → 죽은 mall 제거 후 후보 보충
+7. 정렬: 신뢰점수 ↓ → 가격 ↑
+8. fallback: `search.shopping.naver.com` 검색 URL
+
+→ 단일 소스(네이버)로 좁힌 이유: [ADR-0001](../../../../docs/decisions/0001-naver-only-price-source.md)
+
+---
+
+## 데이터 모델
+
+```prisma
+model ScanResult {
+  id          String   @id @default(cuid())
+  brand       String              // Vision OCR 결과
+  name        String              // Vision OCR 결과
+  notes       String?             // enrichInfo 또는 curated DB
+  description String?             // enrichInfo 또는 curated DB
+  imageUrl    String              // Cloudinary URL
+  matchedSlug String?             // 자체 갤러리 매칭 시
+  prices      Json?               // { items, fetchedAt, koreanName } — 24h 캐시
+  userEmail   String?             // 비로그인 가능 (nullable)
+  tokensUsed  Int?
+  createdAt   DateTime @default(now())
+
+  @@index([brand, name])          // 캐시 조회용
+  @@index([userEmail])
+  @@index([createdAt(sort: Desc)])
+}
+```
+
+`prices` JSON 타입은 `api/scan/prices/[scanId]/route.ts`의 `CachedPrices` 인터페이스와 양방향 계약.
+
+---
+
+## 환경 변수
+
+```env
+OPENAI_API_KEY                        # Vision + enrichInfo + transliterate
+CLOUDINARY_CLOUD_NAME
+NEXT_PUBLIC_CLOUDINARY_CLOUD_PRESET   # unsigned preset
+NAVER_SHOPPING_CLIENT_ID
+NAVER_SHOPPING_CLIENT_SECRET
+SCAN_DEBUG=1                          # (선택) naverShopping 필터링 상세 로그
+```
+
+---
+
+## ⚠️ 이 코드 만질 때 주의
+
+- **`naverShopping.ts` 임계값은 실험으로 튜닝된 값** — `MIN_PRICE_PER_ML=500`, 신뢰점수 가중치(+30/+20/+20/+10~20), 게이트 조건 임의 변경 금지. 변경 시 `SCAN_DEBUG=1`로 회귀 검증 필수.
+- **`prisma/schema.prisma` 변경분이 아직 마이그레이션 미적용** (uncommitted). 새 컬럼 의존 코드 추가 시 `prisma migrate dev` 먼저.
+- **`ScanResult.prices` Json 구조는 prices route의 `CachedPrices`와 계약**. 구조 변경 시 캐시 invalidate 또는 양방향 호환 처리.
+- **Vision 2-pass는 비용 최적화 핵심** — `needsHighResRetry()` 조건(name 길이 ≤5 등) 완화 시 평균 비용 급증. 변경 전 [ADR-0002](../../../../docs/decisions/0002-vision-two-pass-ocr.md) 참고.
+- **UI 토큰**: 하드코딩 hex / HeroUI 기본 색 / 이모지 금지 — 자세한 건 [CLAUDE.md](../../../../CLAUDE.md) + [docs/design-system.md](../../../../docs/design-system.md).
+
+---
+
+## 미구현 (설계엔 있으나 빠진 것)
+
+- `GET /api/scan/history` (로그인 사용자 스캔 이력)
+- 쿠팡·11번가 가격 소스 ([ADR-0001](../../../../docs/decisions/0001-naver-only-price-source.md)에서 의도적 제외)
+- 스캔 결과 공유 OG 카드

--- a/next-server/src/app/api/scan/analyze/route.ts
+++ b/next-server/src/app/api/scan/analyze/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/prisma/db";
+import { getCurrentUser } from "@/src/app/lib/session";
+import { analyzeFragranceFromUrl } from "@/src/app/lib/scan/visionAnalyze";
+import { enrichFragranceInfo } from "@/src/app/lib/scan/enrichInfo";
+import { findFragranceMatch } from "@/src/app/lib/scan/findMatch";
+import { checkRateLimit, getClientKey } from "@/src/app/lib/scan/rateLimit";
+
+export const runtime = "nodejs";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const SCAN_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h — 이전 ScanResult.prices 재사용 기준
+
+export async function POST(req: NextRequest) {
+  try {
+    // 1) 레이트 리밋
+    const clientKey = getClientKey(req);
+    const rate = checkRateLimit(clientKey);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        {
+          message: `요청이 너무 잦아요. ${Math.ceil(rate.resetInMs / 1000)}초 후에 다시 시도해 주세요.`,
+        },
+        { status: 429 },
+      );
+    }
+
+    // 2) multipart 수신
+    const formData = await req.formData();
+    const file = formData.get("file");
+    if (!(file instanceof Blob)) {
+      return NextResponse.json({ message: "사진을 첨부해 주세요." }, { status: 400 });
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ message: "이미지는 10MB 이하 크기로 올려 주세요." }, { status: 400 });
+    }
+
+    // 3) Cloudinary 업로드 (unsigned preset)
+    const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+    const preset = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_PRESET;
+    if (!cloudName || !preset) {
+      console.error("[Scan] Cloudinary 환경변수 누락");
+      return NextResponse.json({ message: "서버 설정에 문제가 있어요. 잠시 후 다시 시도해 주세요." }, { status: 500 });
+    }
+
+    const cloudForm = new FormData();
+    cloudForm.append("file", file, "scan.png");
+    cloudForm.append("upload_preset", preset);
+    cloudForm.append("cloud_name", cloudName);
+
+    const cloudRes = await fetch(
+      `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`,
+      { method: "POST", body: cloudForm },
+    );
+    if (!cloudRes.ok) {
+      const err = await cloudRes.text();
+      console.error("[Scan] Cloudinary 업로드 실패:", err);
+      return NextResponse.json({ message: "이미지 업로드에 실패했어요. 다시 시도해 주세요." }, { status: 500 });
+    }
+    const { secure_url, width: imageWidth, height: imageHeight } = (await cloudRes.json()) as {
+      secure_url: string;
+      width: number;
+      height: number;
+    };
+
+    // 4) Vision 분석
+    const analysis = await analyzeFragranceFromUrl(secure_url);
+
+    if (!analysis.isFragrance) {
+      return NextResponse.json(
+        {
+          message: "향수 사진이 아닌 것 같아요. 향수병이 잘 보이는 사진으로 다시 시도해 주세요.",
+          isFragrance: false,
+          imageUrl: secure_url,
+        },
+        { status: 200 },
+      );
+    }
+
+    if (!analysis.brand || !analysis.name) {
+      return NextResponse.json(
+        {
+          message: "브랜드나 향수 이름을 인식하지 못했어요. 더 선명한 사진으로 다시 시도해 주세요.",
+          isFragrance: true,
+          imageUrl: secure_url,
+          brand: analysis.brand,
+          name: analysis.name,
+        },
+        { status: 200 },
+      );
+    }
+
+    // 5) 자체 갤러리 fuzzy 매칭 (강화된 token 기반)
+    const matched = await findFragranceMatch(analysis.brand, analysis.name);
+
+    // 5-1) Cache-aside: 동일 brand+name + 24h 내 ScanResult 검색
+    //      - prices 캐시 재사용으로 가격 API 호출 절감
+    //      - description/notes 캐시 재사용으로 enrichInfo 호출 절감
+    const recentScans = await prisma.scanResult.findMany({
+      where: {
+        brand: { equals: matched?.brand ?? analysis.brand, mode: "insensitive" },
+        name: { equals: matched?.name ?? analysis.name, mode: "insensitive" },
+        createdAt: { gte: new Date(Date.now() - SCAN_CACHE_TTL_MS) },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+    });
+    const cachedScanWithPrices = recentScans.find((r) => r.prices !== null);
+    const cachedScanWithDesc = recentScans.find(
+      (r) => r.description && r.description.length > 0,
+    );
+
+    // 5-2) curated/캐시/LLM 우선순위로 description·notes 결정
+    let finalDescription: string | null = null;
+    let finalNotes: string | null = null;
+    let enrichTokensUsed = 0;
+
+    if (matched?.description) {
+      // ① 자체 갤러리 매칭: curated 데이터 우선
+      finalDescription = matched.description;
+      finalNotes = matched.notes;
+    } else if (cachedScanWithDesc) {
+      // ② 24h 내 ScanResult 캐시 재사용 — enrichInfo 호출 안 함
+      finalDescription = cachedScanWithDesc.description;
+      finalNotes = cachedScanWithDesc.notes;
+    } else {
+      // ③ LLM 텍스트 호출로 향수 정보 보강 (Phase 3.6) — 스캔 컨텍스트는 항상 생성
+      const enriched = await enrichFragranceInfo(analysis.brand, analysis.name, { generateAlways: true });
+      finalDescription = enriched.description || null;
+      finalNotes = enriched.notes || null;
+      enrichTokensUsed = enriched.tokensUsed;
+    }
+
+    const finalBrand = matched?.brand ?? analysis.brand;
+    const finalName = matched?.name ?? analysis.name;
+
+    const user = await getCurrentUser();
+    const session = await prisma.scanResult.create({
+      data: {
+        brand: finalBrand,
+        name: finalName,
+        notes: finalNotes,
+        description: finalDescription,
+        imageUrl: secure_url,
+        imageWidth: imageWidth ?? null,
+        imageHeight: imageHeight ?? null,
+        matchedSlug: matched?.slug ?? null,
+        userEmail: user?.email ?? null,
+        // Vision OCR + LLM enrichment 합산
+        tokensUsed: analysis.tokensUsed + enrichTokensUsed,
+        // 24h 캐시 hit 시 prices 미리 채워서 가격 카드 즉시 표시
+        prices: cachedScanWithPrices?.prices ?? undefined,
+      },
+    });
+
+    return NextResponse.json({
+      scanId: session.id,
+      isFragrance: true,
+      brand: finalBrand,
+      name: finalName,
+      notes: finalNotes,
+      description: finalDescription,
+      imageUrl: secure_url,
+      matchedFragrance: matched,
+      // 진단·디버깅용 (UI는 사용 안 해도 됨)
+      confidence: matched?.confidence ?? null,
+      fromCache: !!cachedScanWithPrices,
+      tokensUsed: analysis.tokensUsed + enrichTokensUsed,
+    });
+  } catch (err) {
+    console.error("[Scan analyze] error:", err);
+    return NextResponse.json(
+      { message: "분석 중 오류가 발생했어요. 잠시 후 다시 시도해 주세요." },
+      { status: 500 },
+    );
+  }
+}

--- a/next-server/src/app/api/scan/enrich/route.ts
+++ b/next-server/src/app/api/scan/enrich/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { enrichFragranceInfo } from "@/src/app/lib/scan/enrichInfo";
+import { checkRateLimit, getClientKey } from "@/src/app/lib/scan/rateLimit";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  const clientKey = `enrich:${getClientKey(req)}`;
+  const rate = checkRateLimit(clientKey);
+  if (!rate.allowed) {
+    return NextResponse.json(
+      { message: `요청이 너무 잦아요. ${Math.ceil(rate.resetInMs / 1000)}초 후에 다시 시도해 주세요.` },
+      { status: 429 },
+    );
+  }
+
+  try {
+    const body = await req.json().catch(() => null);
+    const brand = typeof body?.brand === "string" ? body.brand.trim() : "";
+    const name = typeof body?.name === "string" ? body.name.trim() : "";
+
+    if (!brand || !name) {
+      return NextResponse.json({ message: "brand와 name이 필요합니다." }, { status: 400 });
+    }
+
+    const enriched = await enrichFragranceInfo(brand, name, { generateAlways: true });
+    return NextResponse.json({
+      description: enriched.description,
+      notes: enriched.notes,
+    });
+  } catch (err) {
+    console.error("[Scan enrich] error:", err);
+    return NextResponse.json({ message: "분석 중 오류가 발생했어요." }, { status: 500 });
+  }
+}

--- a/next-server/src/app/api/scan/prices/[scanId]/route.ts
+++ b/next-server/src/app/api/scan/prices/[scanId]/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/prisma/db";
+import {
+  buildFallbackSearchUrl,
+  searchNaverShopping,
+  type NaverShoppingItem,
+} from "@/src/app/lib/scan/naverShopping";
+import { checkRateLimit, getClientKey } from "@/src/app/lib/scan/rateLimit";
+
+export const runtime = "nodejs";
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+type Params = Promise<{ scanId: string }>;
+
+interface CachedPrices {
+  items: NaverShoppingItem[];
+  fetchedAt: string;
+  /**
+   * 한글 변환된 name (LLM 결과). 24h 안 재호출 시 LLM 비용 절감.
+   * null이면 한글 변환 실패 또는 영문 그대로.
+   */
+  koreanName?: string | null;
+}
+
+export async function GET(req: NextRequest, { params }: { params: Params }) {
+  try {
+    const { scanId } = await params;
+
+    const rate = checkRateLimit(`prices:${getClientKey(req)}`);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        {
+          message: `잠시 후에 다시 시도해 주세요 (${Math.ceil(rate.resetInMs / 1000)}초)`,
+        },
+        { status: 429 },
+      );
+    }
+
+    const scan = await prisma.scanResult.findUnique({ where: { id: scanId } });
+    if (!scan) {
+      return NextResponse.json({ message: "스캔 결과를 찾을 수 없어요." }, { status: 404 });
+    }
+
+    const query = `${scan.brand} ${scan.name}`.trim();
+
+    /**
+     * naverSearchUrl 생성 — brand는 그대로, name은 한글 변환된 것 우선.
+     * 네이버 검색은 띄어쓰기·표기에 민감해서 한글로 정확히 보내야 결과 잘 나옴.
+     * koreanName 없으면 영문 name 그대로 fallback.
+     */
+    const buildSearchUrl = (koreanName: string | null | undefined): string => {
+      const nameForSearch = koreanName || scan.name;
+      const searchQuery = `${scan.brand} ${nameForSearch}`.trim();
+      return buildFallbackSearchUrl(searchQuery);
+    };
+
+    // 24h 캐시 확인 — 캐시에 koreanName 같이 보관, LLM 재호출 회피
+    const cached = scan.prices as unknown as CachedPrices | null;
+    if (cached?.fetchedAt) {
+      const age = Date.now() - new Date(cached.fetchedAt).getTime();
+      if (age < CACHE_TTL_MS) {
+        return NextResponse.json({
+          items: cached.items,
+          cachedAt: cached.fetchedAt,
+          fresh: false,
+          query,
+          naverSearchUrl: buildSearchUrl(cached.koreanName),
+        });
+      }
+    }
+
+    let items: NaverShoppingItem[];
+    let koreanName: string | null = null;
+    try {
+      const result = await searchNaverShopping(scan.brand, scan.name, 5);
+      items = result.items;
+      koreanName = result.koreanName;
+    } catch (err) {
+      console.error("[Scan prices] Naver API error:", err);
+      return NextResponse.json({
+        items: [],
+        naverSearchUrl: buildSearchUrl(null), // 에러 시 영문 fallback
+        error: "가격 정보를 불러올 수 없어요. 네이버 쇼핑에서 직접 검색해 보세요.",
+        query,
+      });
+    }
+
+    const naverSearchUrl = buildSearchUrl(koreanName);
+
+    if (items.length === 0) {
+      return NextResponse.json({
+        items: [],
+        naverSearchUrl,
+        query,
+      });
+    }
+
+    const cacheData: CachedPrices = {
+      items,
+      fetchedAt: new Date().toISOString(),
+      koreanName,
+    };
+    await prisma.scanResult.update({
+      where: { id: scanId },
+      data: { prices: cacheData as object },
+    });
+
+    return NextResponse.json({
+      items,
+      cachedAt: cacheData.fetchedAt,
+      fresh: true,
+      query,
+      naverSearchUrl,
+    });
+  } catch (err) {
+    console.error("[Scan prices] error:", err);
+    return NextResponse.json({ message: "가격 조회에 실패했어요. 잠시 후 다시 시도해 주세요." }, { status: 500 });
+  }
+}

--- a/next-server/src/app/api/scan/similar/[scanId]/naver/route.ts
+++ b/next-server/src/app/api/scan/similar/[scanId]/naver/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/prisma/db';
+import { checkRateLimit, getClientKey } from '@/src/app/lib/scan/rateLimit';
+import { suggestSimilarFragrances } from '@/src/app/lib/scan/suggestSimilarFragrances';
+import { searchNaverShopping, type TrustBadge } from '@/src/app/lib/scan/naverShopping';
+
+export const runtime = 'nodejs';
+
+type Params = Promise<{ scanId: string }>;
+
+const NAVER_RECO_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+// 캐시 버전 — 선정 로직 변경 시 올려서 구버전 캐시 자동 무효화
+const CACHE_VERSION = 9;
+
+export interface NaverRecoItem {
+  brand: string;
+  name: string;
+  price: number;
+  /**
+   * 실제 스토어 직접 URL:
+   *  - 올리브영 결과 → oliveyoung.co.kr/...
+   *  - 백화점 결과 → lotteon.com/... 등
+   *  - 브랜드 직영 → brand.naver.com/dior/...
+   * Naver Shopping 중간 페이지가 아닌 스토어 직접 링크.
+   */
+  storeUrl: string;
+  mall: string;
+  badge: TrustBadge | null;
+  naverThumbnail: string;
+}
+
+interface NaverRecoCache {
+  v?: number;
+  items: NaverRecoItem[];
+  fetchedAt: string;
+}
+
+export async function GET(req: NextRequest, { params }: { params: Params }) {
+  try {
+    const { scanId } = await params;
+
+    const rate = checkRateLimit(`similar-naver:${getClientKey(req)}`);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { message: `잠시 후에 다시 시도해 주세요 (${Math.ceil(rate.resetInMs / 1000)}초)` },
+        { status: 429 },
+      );
+    }
+
+    const scan = await prisma.scanResult.findUnique({
+      where: { id: scanId },
+      select: {
+        brand: true,
+        name: true,
+        description: true,
+        notes: true,
+        naverRecoCache: true,
+      },
+    });
+    if (!scan) {
+      return NextResponse.json({ message: '스캔 결과를 찾을 수 없어요.' }, { status: 404 });
+    }
+
+    // 24h 캐시 확인 — 구버전(v 다름) 캐시는 무효화해서 재조회
+    const cached = scan.naverRecoCache as unknown as NaverRecoCache | null;
+    if (cached?.fetchedAt && cached.v === CACHE_VERSION) {
+      const age = Date.now() - new Date(cached.fetchedAt).getTime();
+      if (age < NAVER_RECO_TTL_MS) {
+        return NextResponse.json({ items: cached.items, source: 'cache' });
+      }
+    }
+
+    // LLM으로 비슷한 향수 추천 생성 (gpt-4o-mini)
+    const suggestions = await suggestSimilarFragrances(
+      scan.brand,
+      scan.name,
+      scan.description ?? null,
+      scan.notes ?? null,
+    );
+
+    if (suggestions.length === 0) {
+      return NextResponse.json({ items: [], source: 'fresh' });
+    }
+
+    // 각 추천 향수를 네이버에서 병렬 검색 (배치 5개) — 4개 채우면 종료
+    const items: NaverRecoItem[] = [];
+    const batchSize = 5;
+
+    for (let i = 0; i < suggestions.length && items.length < 4; i += batchSize) {
+      const batch = suggestions.slice(i, i + batchSize);
+      const results = await Promise.all(
+        batch.map(async (s) => {
+          try {
+            // trust 모드: 배지 우선순위 → trustScore 순, 병행수입 차단 (naverShopping 내부 처리)
+            const result = await searchNaverShopping(s.brand, s.name, 5, 'trust');
+
+            // 적격 스토어만 허용:
+            //   beauty_store : 올리브영·시코르 등 뷰티 전문몰 (storeUrl = 직접 스토어 URL)
+            //   department   : 백화점
+            //   official     : brand.naver.com 브랜드 직영만 (공식수입원 제외)
+            //                  → mallName에 "공식" 있어도 brand.naver.com 아니면 탈락
+            const best = result.items.find(
+              (item) =>
+                item.badges.includes('beauty_store') ||
+                item.badges.includes('department') ||
+                (item.badges.includes('official') && item.url.includes('brand.naver.com')),
+            );
+
+            if (!best) return null;
+
+            return {
+              brand: s.brand,
+              name: s.name,
+              price: best.price,
+              storeUrl: best.url,
+              mall: best.mall,
+              badge: best.badges[0] ?? null,
+              naverThumbnail: best.thumbnail,
+            } satisfies NaverRecoItem;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      for (const r of results) {
+        if (r && items.length < 4) items.push(r);
+      }
+    }
+
+    const cacheData: NaverRecoCache = { v: CACHE_VERSION, items, fetchedAt: new Date().toISOString() };
+    await prisma.scanResult.update({
+      where: { id: scanId },
+      data: { naverRecoCache: cacheData as object },
+    });
+
+    return NextResponse.json({ items, source: 'fresh' });
+  } catch (err) {
+    console.error('[similar/naver] error:', err);
+    return NextResponse.json(
+      { message: '추천을 불러오는 데 실패했어요.' },
+      { status: 500 },
+    );
+  }
+}

--- a/next-server/src/app/api/scan/similar/[scanId]/route.ts
+++ b/next-server/src/app/api/scan/similar/[scanId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/prisma/db';
+import { checkRateLimit, getClientKey } from '@/src/app/lib/scan/rateLimit';
+import {
+  findSimilarFragrances,
+  type SimilarFragrance,
+} from '@/src/app/lib/scan/findSimilarFragrances';
+
+export const runtime = 'nodejs';
+
+type Params = Promise<{ scanId: string }>;
+
+// 갤러리는 향수 등록이 잦지 않아 7일 캐시로 DB 조회 횟수 최소화
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface GalleryCache {
+  items: SimilarFragrance[];
+  fetchedAt: string;
+}
+
+export async function GET(req: NextRequest, { params }: { params: Params }) {
+  try {
+    const { scanId } = await params;
+
+    const rate = checkRateLimit(`similar-gallery:${getClientKey(req)}`);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { message: `잠시 후에 다시 시도해 주세요 (${Math.ceil(rate.resetInMs / 1000)}초)` },
+        { status: 429 },
+      );
+    }
+
+    const scan = await prisma.scanResult.findUnique({
+      where: { id: scanId },
+      select: {
+        matchedSlug: true,
+        notes: true,
+        galleryCache: true,
+      },
+    });
+    if (!scan) {
+      return NextResponse.json({ message: '스캔 결과를 찾을 수 없어요.' }, { status: 404 });
+    }
+
+    // 7일 캐시 확인
+    const cached = scan.galleryCache as unknown as GalleryCache | null;
+    if (cached?.fetchedAt) {
+      const age = Date.now() - new Date(cached.fetchedAt).getTime();
+      if (age < CACHE_TTL_MS) {
+        return NextResponse.json({ items: cached.items, source: 'cache' });
+      }
+    }
+
+    // 갤러리 DB에서 유사 향수 계산 — 외부 API 없음
+    const items = await findSimilarFragrances(
+      scan.matchedSlug ?? null,
+      scan.notes ?? null,
+      6,
+    );
+
+    // 캐시 저장 (빈 결과도 저장 — 반복 계산 방지)
+    const cacheData: GalleryCache = { items, fetchedAt: new Date().toISOString() };
+    await prisma.scanResult.update({
+      where: { id: scanId },
+      data: { galleryCache: cacheData as object },
+    });
+
+    return NextResponse.json({ items, source: 'fresh' });
+  } catch (err) {
+    console.error('[similar/gallery] error:', err);
+    return NextResponse.json(
+      { message: '추천을 불러오는 데 실패했어요.' },
+      { status: 500 },
+    );
+  }
+}

--- a/next-server/src/app/components/scan/CameraCapture.tsx
+++ b/next-server/src/app/components/scan/CameraCapture.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { HiOutlineCamera } from 'react-icons/hi2';
+import toast from 'react-hot-toast';
+import Button from '@/src/app/components/Button';
+
+interface Props {
+  onCapture: (blob: Blob) => void;
+  /** 카메라 active 상태 변화 알림 — 상위에서 entry 영역 layout 분기에 사용 */
+  onActiveChange?: (active: boolean) => void;
+  /** true면 마운트 시 카메라 자동 시작 (뒤로가기 / "다른 향수 스캔하기" 흐름) */
+  autoStart?: boolean;
+}
+
+export default function CameraCapture({ onCapture, onActiveChange, autoStart }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [active, setActive] = useState(false);
+  const [starting, setStarting] = useState(false);
+
+  // active 변화를 상위에 알림 — 디바이더·파일 업로드 숨김/표시 분기용
+  useEffect(() => {
+    onActiveChange?.(active);
+  }, [active, onActiveChange]);
+  // 카메라 stream native aspect ratio. metadata 로드 전 4/3 기본값.
+  // 이 값으로 wrapper 폭을 계산해 video와 아래 버튼 영역 너비를 일치시킴.
+  const [aspectRatio, setAspectRatio] = useState<number>(4 / 3);
+
+  const handleVideoMetadata = () => {
+    const v = videoRef.current;
+    if (v?.videoWidth && v?.videoHeight) {
+      setAspectRatio(v.videoWidth / v.videoHeight);
+    }
+  };
+
+  const stopCamera = () => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+    setActive(false);
+  };
+
+  const startCamera = useCallback(async () => {
+    setStarting(true);
+    try {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error('이 브라우저는 카메라 기능을 지원하지 않아요.');
+      }
+      const s = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: { ideal: 'environment' },
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+        },
+        audio: false,
+      });
+      streamRef.current = s;
+      setActive(true);
+    } catch (e) {
+      console.error('[CameraCapture] getUserMedia failed:', e);
+      const err = e as { name?: string; message?: string };
+      const name = err.name ?? '';
+      const msg = err.message ?? String(e);
+      if (name === 'NotAllowedError' || msg.includes('Permission')) {
+        toast.error(
+          '카메라 권한이 거부됐어요. 브라우저 설정에서 권한을 허용한 뒤 다시 시도하거나, 아래 "파일 선택"을 이용해 주세요.',
+          { duration: 6000 },
+        );
+      } else if (name === 'NotFoundError') {
+        toast.error('연결된 카메라를 찾을 수 없어요.');
+      } else if (name === 'NotReadableError') {
+        toast.error('다른 앱에서 카메라를 사용 중이에요.');
+      } else {
+        toast.error(`카메라 오류가 발생했어요: ${msg}`);
+      }
+    } finally {
+      setStarting(false);
+    }
+  }, []);
+
+  // autoStart: 뒤로가기 / "다른 향수 스캔하기" 진입 시 카메라 자동 시작
+  const didAutoStart = useRef(false);
+  useEffect(() => {
+    if (autoStart && !didAutoStart.current) {
+      didAutoStart.current = true;
+      void startCamera();
+    }
+  }, [autoStart, startCamera]);
+
+  useEffect(() => {
+    if (!active) return;
+    const video = videoRef.current;
+    const stream = streamRef.current;
+    if (!video || !stream) return;
+
+    video.srcObject = stream;
+    video.play().catch((err) => {
+      console.error('[CameraCapture] video.play failed:', err);
+      toast.error('카메라 화면을 불러오지 못했어요. 페이지를 새로고침해 주세요.');
+    });
+  }, [active]);
+
+  const capture = () => {
+    const video = videoRef.current;
+    if (!video || video.videoWidth === 0) {
+      toast.error('카메라가 아직 준비되지 않았어요. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0);
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          toast.error('사진을 저장하지 못했어요. 다시 시도해 주세요.');
+          return;
+        }
+        stopCamera();
+        onCapture(blob);
+      },
+      'image/png',
+      0.95,
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((t) => t.stop());
+      }
+    };
+  }, []);
+
+  if (!active) {
+    return (
+      // 비활성 entry는 자연 폭 + 가운데 정렬 (active 시 비디오가 부모 폭을 채움).
+      <div className="flex justify-center">
+        <Button
+          variant="scent"
+          onClick={startCamera}
+          disabled={starting}
+          className="px-10"
+        >
+          <HiOutlineCamera className="size-4" aria-hidden />
+          {starting ? '카메라 켜는 중...' : '카메라 켜기'}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-center">
+      {/*
+        wrapper 폭을 video 렌더 폭과 일치시켜 아래 버튼 영역과 너비를 맞춤.
+          - width = calc(70vh × aspectRatio): 세로 비디오면 좁아지고, 가로 비디오면 부모 폭에서 clamp
+          - max-w-full로 부모 폭 초과 방지
+          - video는 w-full + style.aspectRatio → wrapper 폭을 그대로 따름
+        디바이스마다 카메라 비율이 다름 (PC 16:9, 모바일 세로 9:16 등).
+        예전처럼 aspect-[4/3] + object-cover로 강제하면 라벨이 잘릴 수 있어 native 비율 유지.
+      */}
+      <div
+        className="flex flex-col gap-3 max-w-full"
+        style={{ width: `calc(70vh * ${aspectRatio})` }}
+      >
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted
+          onLoadedMetadata={handleVideoMetadata}
+          className="block bg-black rounded-2xl border border-lavender-border w-full"
+          style={{ aspectRatio }}
+        />
+        {/* FormSubmitActions 패턴 — 주요(촬영) flex-1, 보조(취소) 자연 폭 */}
+        <div className="flex flex-row gap-2 sm:gap-4">
+          <Button
+            variant="scent"
+            onClick={capture}
+            className="flex-1"
+          >
+            <HiOutlineCamera className="size-4" aria-hidden />
+            촬영
+          </Button>
+          <Button variant="ghostLavender" onClick={stopCamera}>
+            취소
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next-server/src/app/components/scan/FileUploadFallback.tsx
+++ b/next-server/src/app/components/scan/FileUploadFallback.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useRef } from 'react';
+import { HiOutlinePhoto } from 'react-icons/hi2';
+import toast from 'react-hot-toast';
+import Button from '@/src/app/components/Button';
+
+interface Props {
+  onCapture: (blob: Blob) => void;
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export default function FileUploadFallback({ onCapture }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      toast.error('이미지 파일만 업로드할 수 있어요.');
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error('이미지는 10MB 이하 크기로 올려 주세요.');
+      return;
+    }
+
+    onCapture(file);
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        // 모바일에서 후면 카메라 직접 호출 (getUserMedia 권한 없어도 작동)
+        capture="environment"
+        onChange={handleFile}
+        className="hidden"
+        aria-label="향수 사진 선택"
+      />
+      {/* ghostButtonClassName이 이미 px-10을 포함 → 자연 폭 + 가운데 정렬 */}
+      <div className="flex justify-center">
+        <Button
+          variant="ghostLavender"
+          onClick={() => inputRef.current?.click()}
+        >
+          <HiOutlinePhoto className="size-4" aria-hidden />
+          파일 선택
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/next-server/src/app/components/scan/PriceCards.tsx
+++ b/next-server/src/app/components/scan/PriceCards.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { HiOutlineArrowRight } from 'react-icons/hi2';
+
+type TrustBadge = 'verified_catalog' | 'department' | 'official' | 'beauty_store';
+type NaverProductType = '1' | '2' | '3' | '4';
+
+interface PriceItem {
+  mall: string;
+  price: number;
+  url: string;
+  title: string;
+  size: string | null;
+  pricePerMl?: number | null;
+  trustScore?: number;
+  badges?: TrustBadge[];
+  productId?: string;
+  productType?: NaverProductType;
+}
+
+interface Props {
+  scanId: string;
+}
+
+interface ApiResponse {
+  items?: PriceItem[];
+  /** 네이버 쇼핑 자체 검색 페이지 URL (모든 브랜드 공통) */
+  naverSearchUrl?: string;
+  error?: string;
+  query?: string;
+  cachedAt?: string;
+  fresh?: boolean;
+}
+
+/*
+  신뢰 배지 — scent-memories 갤러리 무드 통일 + 가시성 확보.
+  위계:
+    - "최저가" (별도, 그라데이션) — 페이지 hero
+    - "정품 매칭" — lavender outline (주요 신뢰 신호, hero와 분리되면서도 또렷)
+    - 나머지(백화점/공식몰/뷰티) — stone 단색 한 단계 진하게 (카드 배경에서 분명히 분리)
+  '필수' 클래스로 적용되는 outline border 위해 verified_catalog는 별도 border 클래스 포함.
+*/
+const BADGE_META: Record<
+  TrustBadge,
+  { label: string; bg: string; text: string }
+> = {
+  /*
+    배지 디자인 — 솔리드 라벤더 박스로 "한눈에 띄는 배지" 형태.
+    다크모드 명도 반전 위계:
+      - 정품 매칭: bg-lavender (밝은 라벤더 #c8b4ff) + 어두운 글자 → 가장 두드러짐
+      - 보조: bg-lavender-pale (다크값 #3d3555 어두운 라벤더) + 밝은 라벤더 글자
+      두 배지가 명도가 완전히 반대라 한눈에 시각적 분리.
+    라이트모드:
+      - 정품 매칭: lavender-pale 솔리드 + 진한 보라 글자
+      - 보조: lavender-pale 60% (살짝 옅게) + 진한 보라 글자
+  */
+  /*
+    배지 위계 — 구조 자체를 다르게 (filled vs outline)로 한눈에 분리.
+    - 정품 매칭: filled lavender (색감 있는 칠해진 박스) — 강조
+    - 보조: outline ivory (차분한 outline 박스) — 보조
+    웹접근성: 모두 WCAG AAA(7:1) 이상.
+  */
+  verified_catalog: {
+    label: '정품 매칭',
+    // 라이트: 옅은 라벤더 filled (보조 outline과 구조 차이로 분리)
+    // 다크: 솔리드 밝은 라벤더 + 어두운 글자 — 명도 반전으로 보조(어두운 outline)와 한눈에 분리
+    bg: 'bg-lavender-pale dark:bg-lavender',
+    text: 'text-text-primary dark:text-stone-900',
+  },
+  department: {
+    label: '백화점·면세점',
+    bg: 'bg-ivory dark:bg-[var(--color-ivory-soft)] border border-lavender-border',
+    text: 'text-text-secondary',
+  },
+  official: {
+    label: '공식몰',
+    bg: 'bg-ivory dark:bg-[var(--color-ivory-soft)] border border-lavender-border',
+    text: 'text-text-secondary',
+  },
+  beauty_store: {
+    label: '뷰티 전문',
+    bg: 'bg-ivory dark:bg-[var(--color-ivory-soft)] border border-lavender-border',
+    text: 'text-text-secondary',
+  },
+};
+
+/**
+ * productType='2'(가격비교 카탈로그 상품)일 때만 "정품 매칭" 배지. productId만으로
+ * 판단하면 일반 mall 상품(productType=1)에도 잘못 붙어서, 클릭 시 catalog 404 발생.
+ */
+function getDisplayBadges(item: PriceItem): TrustBadge[] {
+  const result: TrustBadge[] = [];
+  if (item.productType === '2') {
+    result.push('verified_catalog');
+  }
+  if (item.badges) {
+    for (const b of item.badges) {
+      if (!result.includes(b)) result.push(b);
+    }
+  }
+  return result;
+}
+
+export default function PriceCards({ scanId }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<PriceItem[]>([]);
+  const [naverSearchUrl, setNaverSearchUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/scan/prices/${scanId}`);
+        const data = (await res.json()) as ApiResponse;
+        if (cancelled) return;
+        if (data.items) {
+          const SMALL_OZ_RE = /(?:^|[^\d])0\.\d{1,2}\s*(?:fl\.?\s*)?oz\b/i;
+          const MIN_TRUSTED_SCORE = 20;
+          setItems(
+            data.items
+              .filter((item) => !SMALL_OZ_RE.test(item.title))
+              .sort((a, b) => {
+                const aTier = (a.trustScore ?? 0) >= MIN_TRUSTED_SCORE ? 0 : 1;
+                const bTier = (b.trustScore ?? 0) >= MIN_TRUSTED_SCORE ? 0 : 1;
+                if (aTier !== bTier) return aTier - bTier;
+                return a.price - b.price;
+              }),
+          );
+        }
+        if (data.naverSearchUrl) setNaverSearchUrl(data.naverSearchUrl);
+        if (data.error) setError(data.error);
+      } catch {
+        if (!cancelled) setError('가격 조회 중 네트워크 오류가 발생했어요');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [scanId]);
+
+  if (loading) {
+    return (
+      <section className="flex flex-col gap-4 animate-pulse">
+        {/* 헤더 */}
+        <div className="flex items-baseline justify-between flex-wrap gap-2">
+          <div className="h-3.5 w-28 rounded-full skeleton-price-bar" />
+          <div className="h-3 w-24 rounded-full skeleton-price-bar-muted" />
+        </div>
+
+        {/* 설명 텍스트 */}
+        <div className="flex flex-col gap-1.5">
+          <div className="h-3 w-full rounded-full skeleton-price-bar-muted" />
+          <div className="h-3 w-4/5 rounded-full skeleton-price-bar-muted" />
+        </div>
+
+        {/* 네이버 쇼핑 링크 카드 */}
+        <div className="flex items-center justify-between gap-2 p-3 rounded-2xl border border-lavender-border bg-ivory dark:bg-[var(--color-ivory-soft)]">
+          <div className="flex flex-col gap-1.5 flex-1">
+            <div className="h-3.5 w-40 rounded-full skeleton-price-bar" />
+            <div className="h-3 w-52 rounded-full skeleton-price-bar-muted" />
+          </div>
+          <div className="size-4 rounded-full skeleton-price-bar-muted shrink-0" />
+        </div>
+
+        {/* 가격 카드 3개 */}
+        <div className="flex flex-col gap-2">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="flex flex-col gap-2 p-3 rounded-2xl border border-lavender-border bg-ivory dark:bg-[var(--color-ivory-soft)]"
+            >
+              {/* 배지 행 — 첫 번째 카드만 */}
+              {i === 0 && (
+                <div className="flex gap-1.5">
+                  <div className="h-5 w-12 rounded-full skeleton-price-bar" />
+                  <div className="h-5 w-16 rounded-full skeleton-price-bar-muted" />
+                </div>
+              )}
+              <div className="flex items-center gap-3">
+                <div className="flex-1 flex flex-col gap-1.5 min-w-0">
+                  <div className="h-3.5 w-4/5 rounded-full skeleton-price-bar" />
+                  <div className="h-3 w-2/5 rounded-full skeleton-price-bar-muted" />
+                </div>
+                <div className="h-4 w-16 rounded-full skeleton-price-bar shrink-0" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl p-5 border border-lavender-border bg-ivory dark:bg-[var(--color-ivory-soft)] text-center">
+        <p className="text-sm text-text-secondary mb-1">
+          {error ?? '가격 정보를 찾지 못했어요.'}
+        </p>
+        {naverSearchUrl && (
+          <a
+            href={naverSearchUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-lavender hover:underline inline-flex items-center gap-1"
+          >
+            네이버 쇼핑에서 검색하기
+            <HiOutlineArrowRight className="size-3" aria-hidden />
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h3 className="text-sm font-bold tracking-[0.2em] uppercase text-stone-500 dark:text-stone-300">
+          정품 최저가 비교
+        </h3>
+        <p className="text-xs text-text-secondary">
+          최저가순 · 네이버 쇼핑
+        </p>
+      </div>
+
+      {/* 안내 문구 — 데이터 신뢰감 유지 + 가격 변동성을 시장 특성으로 프레임 */}
+      <p className="text-[13px] text-text-secondary leading-[1.7] font-light tracking-wide">
+        네이버 쇼핑 기준 최신 가격 정보예요. 가격은 실시간으로 변동될 수 있으니 구매 전 판매처에서 한 번 더 확인해 주세요.
+      </p>
+
+      {/* 네이버 쇼핑 우회 링크 — 갤러리 무드 톤(stone + lavender 포인트)으로 통일 */}
+      {naverSearchUrl && (
+        <a
+          href={naverSearchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-between gap-2 p-3 rounded-2xl border border-lavender-border bg-ivory dark:bg-[var(--color-ivory-soft)] hover:border-lavender dark:hover:border-lavender hover:bg-lavender-pale/40 dark:hover:bg-[var(--color-lavender-pale)] transition-colors"
+        >
+          <div className="flex flex-col min-w-0">
+            <span className="text-sm font-semibold text-text-primary flex items-center gap-1.5">
+              <span
+                className="inline-block w-2 h-2 rounded-full bg-lavender"
+                aria-hidden
+              />
+              네이버 쇼핑에서 직접 검색하기
+            </span>
+            <span className="text-xs text-text-secondary mt-0.5">
+              공식 스토어를 직접 확인하고 싶을 때 이용해 주세요
+            </span>
+          </div>
+          <HiOutlineArrowRight
+            className="size-4 text-text-secondary shrink-0"
+            aria-hidden
+          />
+        </a>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {items.map((item, idx) => {
+          const displayBadges = getDisplayBadges(item);
+          return (
+            <a
+              key={`${item.mall}-${idx}`}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              /*
+                다크모드에서 --color-card-bg(#f1ecfe 밝은 라벤더) + --color-text-primary(밝은 라벤더)는
+                "밝은 배경 + 밝은 글자"라 안 보임. stone 톤으로 명시적 색상 적용.
+              */
+              className="flex flex-col gap-2 p-3 rounded-2xl border border-lavender-border bg-ivory dark:bg-[var(--color-ivory-soft)] hover:border-lavender dark:hover:border-lavender hover:bg-lavender-pale/40 dark:hover:bg-[var(--color-lavender-pale)] transition-colors"
+            >
+              {(idx === 0 || displayBadges.length > 0) && (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {idx === 0 && (
+                    /*
+                      inline-flex items-center로 배지 안 글자 세로 가운데 정렬.
+                      다크모드의 bg-gradient-scent는 밝은 파스텔(#fff5f8/#ddd0ff/#ffe8b4)이라
+                      text-white면 글자가 묻힘 — 다크에선 어두운 글자로 대비 확보.
+                    */
+                    <span className="inline-flex items-center bg-gradient-scent text-white dark:text-stone-900 text-xs font-medium tracking-[0.04em] leading-none px-3 py-1.5 rounded-full">
+                      최저가
+                    </span>
+                  )}
+                  {displayBadges.map((b) => {
+                    const meta = BADGE_META[b];
+                    return (
+                      <span
+                        key={b}
+                        className={`inline-flex items-center ${meta.bg} ${meta.text} text-xs font-medium tracking-[0.04em] leading-none px-3 py-1.5 rounded-full`}
+                      >
+                        {meta.label}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+
+              <div className="flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium leading-tight truncate text-text-primary">
+                    {item.title}
+                  </p>
+                  <p className="text-xs text-text-secondary mt-0.5 flex items-center flex-wrap gap-1">
+                    <span className="truncate">{item.mall}</span>
+                    {item.size && (
+                      <span className="px-2 py-0.5 rounded bg-lavender-pale/40 dark:bg-lavender/15 text-text-secondary text-xs">
+                        {item.size}
+                      </span>
+                    )}
+                    {item.pricePerMl != null && (
+                      <span className="text-text-secondary text-xs">
+                        ₩{item.pricePerMl.toLocaleString()}/ml
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <div className="text-right shrink-0">
+                  <p className="text-base font-bold text-text-primary">
+                    ₩{item.price.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+
+    </section>
+  );
+}

--- a/next-server/src/app/components/scan/ScanClient.tsx
+++ b/next-server/src/app/components/scan/ScanClient.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import toast from 'react-hot-toast';
+import PointsLoading from '@/src/app/components/PointsLoading';
+import CameraCapture from './CameraCapture';
+import FileUploadFallback from './FileUploadFallback';
+import ScanPreview from './ScanPreview';
+
+type Stage = 'idle' | 'previewing' | 'analyzing';
+
+export default function ScanClient() {
+  const router = useRouter();
+  const [stage, setStage] = useState<Stage>('idle');
+  const [capturedBlob, setCapturedBlob] = useState<Blob | null>(null);
+  const [capturedUrl, setCapturedUrl] = useState<string | null>(null);
+  // CameraCapture의 active 상태 — idle 영역 폭/디바이더 표시 분기
+  const [cameraActive, setCameraActive] = useState(false);
+  // ?camera=true 파라미터 감지 — 뒤로가기 / "다른 향수 스캔하기" 진입 시 카메라 자동 시작
+  const [autoStartCamera, setAutoStartCamera] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('camera') === 'true') setAutoStartCamera(true);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (capturedUrl) URL.revokeObjectURL(capturedUrl);
+    };
+  }, [capturedUrl]);
+
+  const handleCapture = (blob: Blob) => {
+    if (capturedUrl) URL.revokeObjectURL(capturedUrl);
+    setCapturedBlob(blob);
+    setCapturedUrl(URL.createObjectURL(blob));
+    setStage('previewing');
+  };
+
+  const resetAll = () => {
+    if (capturedUrl) URL.revokeObjectURL(capturedUrl);
+    setCapturedBlob(null);
+    setCapturedUrl(null);
+    setStage('idle');
+  };
+
+  const handleAnalyze = async () => {
+    if (!capturedBlob) return;
+    setStage('analyzing');
+    try {
+      const formData = new FormData();
+      formData.append('file', capturedBlob, 'scan.png');
+      const res = await fetch('/api/scan/analyze', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.message ?? '분석에 실패했어요. 잠시 후 다시 시도해 주세요.');
+        setStage('previewing');
+        return;
+      }
+
+      if (!data.isFragrance || !data.brand || !data.name) {
+        toast.error(data.message ?? '향수를 인식하지 못했어요.');
+        setStage('previewing');
+        return;
+      }
+
+      // 현재 /scan 히스토리 항목을 ?camera=true로 교체 — 결과 페이지에서 뒤로가기 시 카메라 자동 시작
+      router.replace('/scan?camera=true');
+      router.push(`/scan/result/${data.scanId}`);
+    } catch (err) {
+      console.error('[ScanClient] analyze error:', err);
+      toast.error('네트워크 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
+      setStage('previewing');
+    }
+  };
+
+  return (
+    <>
+      {/*
+        페이지 컨테이너(px / max-w / 제목)는 page.tsx에서 처리.
+        여기서는 stage별 컨텐츠 레이아웃만 담당.
+      */}
+      <section className="mt-6 md:mt-10">
+        {stage === 'idle' && (
+          /*
+            카메라 비활성: max-w-sm(384px) — 버튼/디바이더/안내가 같은 좁은 컬럼에 깔끔히 정렬
+            카메라 활성: max-w-2xl(672px) — 비디오 폭 확보 (디바이더·파일선택은 숨김)
+          */
+          <div
+            className={`flex flex-col mx-auto w-full ${
+              cameraActive ? 'max-w-2xl' : 'max-w-sm'
+            }`}
+          >
+            <p className="text-center text-[13px] md:text-sm text-stone-500 dark:text-stone-400 leading-[1.8] font-light tracking-wide mb-8 md:mb-10">
+              카메라로 향수병을 촬영하거나 갤러리에서 사진을 선택하면
+              <br />
+              AI가 어떤 향수인지 알려드려요.
+            </p>
+
+            <CameraCapture
+              onCapture={handleCapture}
+              onActiveChange={setCameraActive}
+              autoStart={autoStartCamera}
+            />
+
+            {!cameraActive && (
+              <>
+                <div className="flex items-center gap-3 my-6">
+                  <div className="flex-1 h-px bg-stone-200/60 dark:bg-stone-700/40" />
+                  <span className="text-xs uppercase tracking-[0.2em] text-stone-400 dark:text-stone-500">
+                    또는
+                  </span>
+                  <div className="flex-1 h-px bg-stone-200/60 dark:bg-stone-700/40" />
+                </div>
+
+                <FileUploadFallback onCapture={handleCapture} />
+
+                <p className="text-[13px] text-stone-400 dark:text-stone-500 mt-8 text-center leading-[1.8] font-light tracking-wide">
+                  촬영한 사진은 분석 후 안전하게 보관돼요.
+                  <br />
+                  본인이 직접 촬영한 사진만 올려 주세요.
+                </p>
+              </>
+            )}
+          </div>
+        )}
+
+        {stage === 'previewing' && capturedUrl && (
+          <ScanPreview
+            imageUrl={capturedUrl}
+            onRetake={resetAll}
+            onAnalyze={handleAnalyze}
+          />
+        )}
+      </section>
+
+      {stage === 'analyzing' && (
+        <PointsLoading loadingMessage="AI가 향수를 분석하고 있어요 (약 10~15초)" />
+      )}
+    </>
+  );
+}

--- a/next-server/src/app/components/scan/ScanPreview.tsx
+++ b/next-server/src/app/components/scan/ScanPreview.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { HiOutlineMagnifyingGlass } from 'react-icons/hi2';
+import Button from '@/src/app/components/Button';
+
+interface Props {
+  imageUrl: string;
+  onRetake: () => void;
+  onAnalyze: () => void;
+}
+
+export default function ScanPreview({ imageUrl, onRetake, onAnalyze }: Props) {
+  // 캡처된 이미지의 native aspect ratio — onLoad에서 측정.
+  // CameraCapture와 동일한 패턴으로 wrapper 폭을 이미지 비율에 맞춰서
+  // 카메라 영상 크기 = 미리보기 크기 일치 (정사각형 강제 letterbox 제거).
+  const [aspectRatio, setAspectRatio] = useState<number>(4 / 3);
+
+  const handleImgLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget;
+    if (img.naturalWidth && img.naturalHeight) {
+      setAspectRatio(img.naturalWidth / img.naturalHeight);
+    }
+  };
+
+  return (
+    <div className="flex justify-center">
+      {/*
+        wrapper 폭 = calc(70vh × aspectRatio) — CameraCapture와 동일한 계산.
+        그러면 미리보기 박스가 카메라 영상과 같은 크기로 표시되고
+        아래 버튼 영역도 그 폭에 자연스럽게 맞춰짐.
+      */}
+      <div
+        className="flex flex-col gap-5 max-w-full"
+        style={{ width: `calc(70vh * ${aspectRatio})` }}
+      >
+        <p className="text-center text-sm md:text-[15px] font-medium text-stone-700 dark:text-stone-200">
+          이 사진으로 분석할까요?
+        </p>
+
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={imageUrl}
+          alt="촬영한 향수 사진"
+          onLoad={handleImgLoad}
+          className="block rounded-2xl bg-[var(--color-card-bg)] w-full"
+          style={{ aspectRatio }}
+        />
+
+        <p className="text-[13px] text-stone-400 dark:text-stone-500 text-center font-light tracking-wide">
+          향수병이 선명하게 보일수록 더 정확하게 인식할 수 있어요.
+        </p>
+
+        <div className="flex flex-row gap-2 sm:gap-4">
+          <Button
+            variant="scent"
+            onClick={onAnalyze}
+            className="flex-1"
+          >
+            <HiOutlineMagnifyingGlass className="size-4" aria-hidden />
+            분석하기
+          </Button>
+          <Button variant="ghostLavender" onClick={onRetake}>
+            다시 찍기
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/next-server/src/app/components/scan/ScanResult.tsx
+++ b/next-server/src/app/components/scan/ScanResult.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { HiOutlineArrowRight, HiOutlineCamera, HiOutlinePlus } from 'react-icons/hi2';
+import Button from '@/src/app/components/Button';
+import PriceCards from './PriceCards';
+import SimilarGallery from './SimilarGallery';
+import SimilarNaverReco from './SimilarNaverReco';
+import { useScanPrefillStore } from '@/src/app/store/scanPrefillStore';
+
+interface MatchedFragrance {
+  slug: string;
+  brand: string;
+  name: string;
+  images: string[];
+}
+
+export interface ScanResultData {
+  scanId: string;
+  brand: string;
+  name: string;
+  notes?: string;
+  description?: string;
+  imageUrl: string;
+  imageWidth?: number | null;
+  imageHeight?: number | null;
+  matchedFragrance?: MatchedFragrance | null;
+}
+
+interface Props {
+  data: ScanResultData;
+}
+
+export default function ScanResult({ data }: Props) {
+  const { brand, name, imageUrl, imageWidth, imageHeight, matchedFragrance } = data;
+  const [imgLoaded, setImgLoaded] = useState(false);
+  const router = useRouter();
+  const setPrefill = useScanPrefillStore((s) => s.set);
+
+  const [description, setDescription] = useState(data.description ?? '');
+  const [notes, setNotes] = useState(data.notes ?? '');
+  const needsEnrich = !data.description || !data.notes;
+  // 처음부터 로딩 상태로 시작해 마운트 직후 빈 화면 깜빡임 방지
+  const [isEnriching, setIsEnriching] = useState(needsEnrich);
+  const [enrichFailed, setEnrichFailed] = useState(false);
+
+  useEffect(() => {
+    if (!needsEnrich) return;
+    fetch('/api/scan/enrich', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ brand, name }),
+    })
+      .then((r) => r.json())
+      .then((d: { description?: string; notes?: string }) => {
+        if (d.description) setDescription(d.description);
+        if (d.notes) setNotes(d.notes);
+        if (!d.description && !d.notes) setEnrichFailed(true);
+      })
+      .catch(() => setEnrichFailed(true))
+      .finally(() => setIsEnriching(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+
+  return (
+    /*
+      FragranceDetail 톤으로 통일 — 카드(border + bg + padding) wrapping 제거.
+      그라데이션 헤딩 + border-t 섹션 구분 + 톤 다운된 본문으로 정보 위계 표현.
+    */
+    <div className="mx-auto w-full max-w-5xl flex flex-col gap-10 lg:flex-row lg:items-start lg:gap-12">
+      {/* 좌: 이미지 + 액션 버튼 — sticky로 스크롤 중에도 항상 보임 */}
+      <div className="w-full max-w-md mx-auto lg:max-w-none lg:w-[400px] lg:mx-0 lg:shrink-0 lg:sticky lg:top-[calc(var(--header-height)+1.5rem)]">
+        <div
+          className="relative rounded-2xl overflow-hidden bg-[var(--color-lavender-pale)]"
+          style={imageWidth && imageHeight ? { aspectRatio: `${imageWidth}/${imageHeight}` } : { aspectRatio: '3/4' }}
+        >
+          {/* 로딩 중 스켈레톤 */}
+          {!imgLoaded && (
+            <div className="absolute inset-0 animate-pulse bg-[var(--color-lavender-pale)]" />
+          )}
+          <Image
+            src={imageUrl}
+            alt={`${brand} ${name}`}
+            fill
+            sizes="(max-width: 1024px) 448px, 400px"
+            className={`object-contain transition-opacity duration-500 ${imgLoaded ? 'opacity-100' : 'opacity-0'}`}
+            onLoad={() => setImgLoaded(true)}
+          />
+        </div>
+        {/* 이미지 아래 액션 버튼 */}
+        <div className="mt-4 flex flex-row gap-3 w-full">
+          {matchedFragrance ? (
+            <Link href={`/fragrance/${matchedFragrance.slug}`} className="flex-[3]">
+              <Button variant="scent" fullWidth className="!px-4">
+                <HiOutlineArrowRight className="size-4 shrink-0" aria-hidden />
+                향수 페이지 보기
+              </Button>
+            </Link>
+          ) : (
+            <Button
+              variant="scent"
+              fullWidth
+              className="flex-[3] !px-4"
+              disabled={isEnriching}
+              onClick={() => {
+                setPrefill({ brand, name, description, notes, imageUrl });
+                router.push('/fragrance/create');
+              }}
+            >
+              <HiOutlinePlus className="size-4 shrink-0" aria-hidden />
+              {isEnriching ? '불러오는 중...' : 'Scent Memories에 등록'}
+            </Button>
+          )}
+          <Link href="/scan?camera=true" className="flex-[2]">
+            <Button variant="ghostLavender" fullWidth className="whitespace-nowrap !px-4">
+              <HiOutlineCamera className="size-4 shrink-0" aria-hidden />
+              다른 향수 스캔
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* 우: 정보 영역 */}
+      <div className="flex-1 flex flex-col gap-10 min-w-0 w-full">
+        {/* 설명 섹션 — 로딩 / 내용 / 실패 세 상태 */}
+        {isEnriching && !description ? (
+          <div className="space-y-2 animate-pulse">
+            <div className="h-3 bg-[var(--color-lavender-pale)] rounded w-full" />
+            <div className="h-3 bg-[var(--color-lavender-pale)] rounded w-4/5" />
+            <div className="h-3 bg-[var(--color-lavender-pale)] rounded w-3/5" />
+          </div>
+        ) : description ? (
+          <p className="text-[13px] md:text-[14px] leading-[1.8] text-stone-600 dark:text-stone-300/90 font-light tracking-wide">
+            {description}
+          </p>
+        ) : enrichFailed ? (
+          <p className="text-[13px] md:text-[14px] text-stone-400 dark:text-stone-500 font-light">
+            향수 설명 정보를 찾지 못했어요.
+          </p>
+        ) : null}
+
+        {/* 노트 섹션 — 로딩 / 내용 / 실패 세 상태 */}
+        <div className="pt-8 border-t border-stone-200/60 dark:border-stone-700/40">
+          <h3 className="text-sm font-bold tracking-[0.2em] uppercase text-stone-400 dark:text-stone-300 mb-4">
+            향 노트
+          </h3>
+          {isEnriching && !notes ? (
+            <div className="space-y-2 animate-pulse">
+              <div className="h-3 bg-[var(--color-lavender-pale)] rounded w-2/5" />
+              <div className="h-3 bg-[var(--color-lavender-pale)] rounded w-3/5" />
+              <div className="h-3 bg-[var(--color-lavender-pale)] rounded w-2/5" />
+            </div>
+          ) : notes ? (
+            <p className="text-[13px] md:text-[14px] leading-[1.7] text-stone-600 dark:text-stone-300 font-light whitespace-pre-wrap">
+              {notes}
+            </p>
+          ) : enrichFailed ? (
+            <p className="text-[13px] md:text-[14px] text-stone-400 dark:text-stone-500 font-light">
+              노트 정보를 찾지 못했어요.
+            </p>
+          ) : null}
+        </div>
+
+        {matchedFragrance && (
+          <div className="pt-8 border-t border-stone-200/60 dark:border-stone-700/40">
+            <h3 className="text-sm font-bold tracking-[0.2em] uppercase text-stone-400 dark:text-stone-300 mb-4">
+              갤러리에 등록된 향수예요
+            </h3>
+            <Link
+              href={`/fragrance/${matchedFragrance.slug}`}
+              className="flex items-center gap-4 group"
+            >
+              {matchedFragrance.images[0] && (
+                <div className="relative w-20 h-20 rounded-xl overflow-hidden bg-ivory shrink-0 border border-stone-200/60 dark:border-stone-700/40">
+                  <Image
+                    src={matchedFragrance.images[0]}
+                    alt={matchedFragrance.name}
+                    fill
+                    sizes="80px"
+                    className="object-contain p-1"
+                  />
+                </div>
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-text-primary truncate group-hover:text-lavender transition-colors">
+                  {matchedFragrance.brand} · {matchedFragrance.name}
+                </p>
+                <p className="text-xs text-stone-400 dark:text-stone-500 mt-1 flex items-center gap-1">
+                  상세 페이지로 이동
+                  <HiOutlineArrowRight
+                    className="size-3 transition-transform group-hover:translate-x-0.5"
+                    aria-hidden
+                  />
+                </p>
+              </div>
+            </Link>
+          </div>
+        )}
+
+        <div className="pt-8 border-t border-stone-200/60 dark:border-stone-700/40">
+          <PriceCards scanId={data.scanId} />
+        </div>
+
+        <div className="pt-8 border-t border-stone-200/60 dark:border-stone-700/40">
+          <SimilarGallery scanId={data.scanId} />
+        </div>
+
+        <div className="pt-8 border-t border-stone-200/60 dark:border-stone-700/40">
+          <SimilarNaverReco scanId={data.scanId} />
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/next-server/src/app/components/scan/SimilarGallery.tsx
+++ b/next-server/src/app/components/scan/SimilarGallery.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+interface GalleryItem {
+  slug: string;
+  brand: string;
+  name: string;
+  images: string[];
+  similarity: number;
+  method: 'score' | 'notes';
+}
+
+interface ApiResponse {
+  items: GalleryItem[];
+  source: 'cache' | 'fresh';
+}
+
+interface Props {
+  scanId: string;
+}
+
+export default function SimilarGallery({ scanId }: Props) {
+  const [items, setItems] = useState<GalleryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/scan/similar/${scanId}`);
+        const data = (await res.json()) as ApiResponse;
+        if (!cancelled) setItems(data.items ?? []);
+      } catch {
+        // 핵심 기능이 아니므로 에러 시 섹션 숨김
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [scanId]);
+
+  if (!loading && items.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h3 className="text-sm font-bold tracking-[0.2em] uppercase text-stone-500 dark:text-stone-300">
+          Scent Memories에서 찾은 비슷한 향수
+        </h3>
+        <p className="text-xs text-text-secondary">
+          {loading ? '불러오는 중...' : `총 ${items.length}종`}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        {loading
+          ? [0, 1, 2].map((i) => (
+              <div key={i} className="flex flex-col gap-2 animate-pulse">
+                <div className="aspect-[3/4] rounded-2xl bg-[var(--color-card-bg)] dark:bg-[var(--color-ivory-soft)]" />
+                <div className="flex flex-col gap-1.5 px-0.5">
+                  <div className="h-2.5 w-2/5 rounded-full bg-[var(--color-card-bg)] dark:bg-[var(--color-ivory-soft)]" />
+                  <div className="h-3 w-4/5 rounded-full bg-[var(--color-card-bg)] dark:bg-[var(--color-ivory-soft)]" />
+                </div>
+              </div>
+            ))
+          : items.map((item) => (
+              <Link
+                key={item.slug}
+                href={`/fragrance/${item.slug}`}
+                className="group flex flex-col gap-2"
+              >
+                <div className="relative aspect-[3/4] rounded-2xl overflow-hidden bg-[var(--color-card-bg)] dark:bg-[var(--color-ivory-soft)] border border-[var(--color-card-border)] group-hover:border-lavender transition-colors">
+                  {item.images[0] ? (
+                    <Image
+                      src={item.images[0]}
+                      alt={`${item.brand} ${item.name}`}
+                      fill
+                      sizes="(max-width: 768px) 33vw, 200px"
+                      className="object-contain p-3 transition-transform duration-300 group-hover:scale-[1.03]"
+                    />
+                  ) : (
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <span className="text-xs text-text-secondary">no image</span>
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-col gap-0.5 px-0.5">
+                  <p className="text-[11px] text-text-secondary font-light truncate">
+                    {item.brand}
+                  </p>
+                  <p className="text-[13px] font-medium text-text-primary truncate group-hover:text-lavender transition-colors leading-snug">
+                    {item.name}
+                  </p>
+                </div>
+              </Link>
+            ))}
+      </div>
+    </section>
+  );
+}

--- a/next-server/src/app/components/scan/SimilarNaverReco.tsx
+++ b/next-server/src/app/components/scan/SimilarNaverReco.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { HiOutlineArrowTopRightOnSquare } from 'react-icons/hi2';
+
+type TrustBadge = 'verified_catalog' | 'department' | 'official' | 'beauty_store';
+
+interface NaverRecoItem {
+  brand: string;
+  name: string;
+  price: number;
+  storeUrl: string;  // 올리브영·백화점·brand.naver.com 직접 URL
+  mall: string;
+  badge: TrustBadge | null;
+  naverThumbnail: string;
+}
+
+interface ApiResponse {
+  items: NaverRecoItem[];
+  source: 'cache' | 'fresh';
+}
+
+interface Props {
+  scanId: string;
+}
+
+const BADGE_LABEL: Record<TrustBadge, string> = {
+  beauty_store: '뷰티 전문몰',
+  department: '백화점',
+  official: '공식몰',
+  verified_catalog: '정품 매칭',
+};
+
+/** 결과 아이템들의 스토어 종류를 요약 (중복 제거, 최대 2종) */
+function summarizeStores(items: NaverRecoItem[]): string {
+  const seen = new Set<TrustBadge>();
+  for (const item of items) {
+    if (item.badge) seen.add(item.badge);
+  }
+  const labels = [...seen]
+    .map((b) => BADGE_LABEL[b])
+    .filter(Boolean)
+    .slice(0, 2);
+  return labels.length > 0 ? labels.join(' · ') : '정품 판매처';
+}
+
+export default function SimilarNaverReco({ scanId }: Props) {
+  const [items, setItems] = useState<NaverRecoItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/scan/similar/${scanId}/naver`);
+        const data = (await res.json()) as ApiResponse;
+        if (!cancelled) setItems(data.items ?? []);
+      } catch {
+        // 핵심 기능이 아니므로 에러 시 섹션 숨김
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [scanId]);
+
+  if (!loading && items.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h3 className="text-sm font-bold tracking-[0.2em] uppercase text-stone-500 dark:text-stone-300">
+          AI가 추천하는 비슷한 향수
+        </h3>
+        <p className="text-xs text-text-secondary">
+          {loading
+            ? '올리브영 · 백화점 · 공식몰 확인 중...'
+            : `${items.length}종 · ${summarizeStores(items)}`}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        {loading
+          ? [0, 1].map((i) => (
+              <div key={i} className="flex flex-col gap-2 animate-pulse">
+                <div className="aspect-square rounded-2xl bg-[var(--color-lavender-pale)]" />
+                <div className="flex flex-col gap-1.5 px-0.5">
+                  <div className="h-2.5 w-2/5 rounded-full bg-[var(--color-lavender-pale)]" />
+                  <div className="h-3 w-4/5 rounded-full bg-[var(--color-lavender-pale)]" />
+                  <div className="h-2.5 w-3/5 rounded-full bg-[var(--color-lavender-pale)]" />
+                </div>
+              </div>
+            ))
+          : items.map((item, idx) => {
+              const imgSrc = item.naverThumbnail?.startsWith('http') ? item.naverThumbnail : '';
+
+              return (
+                <a
+                  key={idx}
+                  href={item.storeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex flex-col gap-2"
+                >
+                  <div className="relative aspect-square rounded-2xl overflow-hidden bg-[var(--color-lavender-pale)] border border-[var(--color-card-border)] group-hover:border-lavender transition-colors">
+                    {imgSrc ? (
+                      <Image
+                        src={imgSrc}
+                        alt={`${item.brand} ${item.name}`}
+                        fill
+                        sizes="(max-width: 768px) 50vw, 240px"
+                        className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <span className="text-xs text-text-secondary">no image</span>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col gap-1 px-0.5">
+                    <p className="text-[11px] text-text-secondary font-light truncate">
+                      {item.brand}
+                    </p>
+                    <p className="text-[13px] font-medium text-text-primary truncate group-hover:text-lavender transition-colors leading-snug">
+                      {item.name}
+                    </p>
+
+                    {/* 스토어 배지 + 몰 이름 */}
+                    <div className="mt-0.5 flex items-center gap-1.5 flex-wrap">
+                      {item.badge && (
+                        <span className="shrink-0 inline-flex items-center bg-[var(--color-lavender-pale)] text-text-secondary text-[10px] font-medium px-1.5 py-0.5 rounded-full leading-none">
+                          {BADGE_LABEL[item.badge]}
+                        </span>
+                      )}
+                      <span className="text-[11px] text-text-secondary truncate">
+                        {item.mall}
+                      </span>
+                    </div>
+
+                    {/* 가격 + 바로가기 */}
+                    <div className="flex items-center gap-1 group/link">
+                      <span className="text-[12px] font-semibold text-text-primary group-hover/link:text-lavender transition-colors">
+                        ₩{item.price.toLocaleString()}
+                      </span>
+                      <HiOutlineArrowTopRightOnSquare
+                        className="size-3 text-text-secondary shrink-0 group-hover/link:text-lavender transition-colors"
+                        aria-hidden
+                      />
+                    </div>
+                  </div>
+                </a>
+              );
+            })}
+      </div>
+    </section>
+  );
+}

--- a/next-server/src/app/globals.css
+++ b/next-server/src/app/globals.css
@@ -957,6 +957,24 @@ h6 {
   border-color: var(--color-lavender-border);
 }
 
+/*
+  가격 비교 스켈레톤 바 — var(--color-lavender) 기반.
+  라이트(#b094e0): 85% / 60% opacity
+  다크  (#c8b4ff): 52% / 38% opacity — 어두운 배경에서 대비 확보
+*/
+.skeleton-price-bar {
+  background-color: color-mix(in srgb, var(--color-lavender) 85%, transparent);
+}
+.dark .skeleton-price-bar {
+  background-color: color-mix(in srgb, var(--color-lavender) 52%, transparent);
+}
+.skeleton-price-bar-muted {
+  background-color: color-mix(in srgb, var(--color-lavender) 60%, transparent);
+}
+.dark .skeleton-price-bar-muted {
+  background-color: color-mix(in srgb, var(--color-lavender) 38%, transparent);
+}
+
 /* 폼 입력 필드용 공통 스켈레톤 스타일 */
 .form-input-skeleton {
   @apply w-full space-y-2 skeleton-pulse;

--- a/next-server/src/app/lib/scan/checkNaverAvailability.ts
+++ b/next-server/src/app/lib/scan/checkNaverAvailability.ts
@@ -1,0 +1,130 @@
+import prisma from '@/prisma/db';
+import {
+  searchNaverShopping,
+  type NaverShoppingItem,
+  type TrustBadge,
+} from './naverShopping';
+import type { SimilarFragrance } from './findSimilarFragrances';
+
+export type { TrustBadge };
+
+/** Fragrance.naverCache JSON 형태 */
+interface NaverCacheEntry {
+  available: boolean;
+  item: NaverShoppingItem | null;
+  fetchedAt: string;
+  koreanName: string | null;
+}
+
+/** 네이버 판매 확인된 유사 향수 */
+export interface VerifiedSimilarFragrance extends SimilarFragrance {
+  lowestPrice: number;
+  naverUrl: string;
+  mall: string;
+  badge: TrustBadge | null;
+  naverThumbnail: string;
+}
+
+const NAVER_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7일
+
+/**
+ * 단일 향수의 네이버 판매 여부 확인.
+ * Fragrance.naverCache (7일 TTL) 우선 사용 — 만료 시 API 호출 후 갱신.
+ */
+async function checkOne(
+  candidate: SimilarFragrance,
+): Promise<VerifiedSimilarFragrance | null> {
+  // 1. DB 캐시 확인
+  const row = await prisma.fragrance.findUnique({
+    where: { slug: candidate.slug },
+    select: { naverCache: true },
+  });
+
+  if (row?.naverCache) {
+    const cached = row.naverCache as unknown as NaverCacheEntry;
+    const age = Date.now() - new Date(cached.fetchedAt).getTime();
+    // thumbnail이 없는 구버전 캐시는 만료 처리 → 재조회
+    const hasThumbnail = cached.item?.thumbnail !== undefined && cached.item.thumbnail !== '';
+    if (age < NAVER_CACHE_TTL_MS && hasThumbnail) {
+      if (!cached.available || !cached.item) return null;
+      return buildVerified(candidate, cached.item);
+    }
+  }
+
+  // 2. 캐시 없음/만료 → 네이버 API 호출 (결과 1개만)
+  let entry: NaverCacheEntry;
+  try {
+    const result = await searchNaverShopping(candidate.brand, candidate.name, 1);
+    const item = result.items[0] ?? null;
+    entry = {
+      available: item !== null,
+      item,
+      fetchedAt: new Date().toISOString(),
+      koreanName: result.koreanName,
+    };
+  } catch (err) {
+    console.warn(
+      `[checkNaverAvailability] API 오류 ${candidate.brand} ${candidate.name}:`,
+      err,
+    );
+    // 오류 시 캐시 저장 안 함 — 다음 요청에 재시도
+    return null;
+  }
+
+  // 3. 캐시 저장
+  await prisma.fragrance.update({
+    where: { slug: candidate.slug },
+    data: { naverCache: entry as object },
+  });
+
+  if (!entry.available || !entry.item) return null;
+  return buildVerified(candidate, entry.item);
+}
+
+function buildVerified(
+  candidate: SimilarFragrance,
+  item: NaverShoppingItem,
+): VerifiedSimilarFragrance {
+  return {
+    ...candidate,
+    lowestPrice: item.price,
+    naverUrl: item.url,
+    mall: item.mall,
+    badge: item.badges[0] ?? null,
+    naverThumbnail: item.thumbnail,
+  };
+}
+
+/**
+ * 후보 목록을 배치로 네이버 확인.
+ * 5개씩 병렬 처리 → resultCount개 채우면 즉시 종료.
+ *
+ * 왜 배치?
+ *  - 캐시 미스가 겹치면 동시 네이버 API 호출이 10개까지 올라갈 수 있음
+ *  - 5개씩 끊어서 호출 수 조절
+ *  - 캐시 히트가 많으면 DB 조회만이라 빠름
+ */
+export async function checkNaverAvailability(
+  candidates: SimilarFragrance[],
+  resultCount = 6,
+): Promise<VerifiedSimilarFragrance[]> {
+  const results: VerifiedSimilarFragrance[] = [];
+  const batchSize = 5;
+
+  for (
+    let i = 0;
+    i < candidates.length && results.length < resultCount;
+    i += batchSize
+  ) {
+    const batch = candidates.slice(i, i + batchSize);
+    const checked = await Promise.all(batch.map(checkOne));
+
+    for (const item of checked) {
+      if (item && results.length < resultCount) {
+        results.push(item);
+      }
+    }
+  }
+
+  return results;
+}

--- a/next-server/src/app/lib/scan/enrichInfo.ts
+++ b/next-server/src/app/lib/scan/enrichInfo.ts
@@ -1,0 +1,170 @@
+/**
+ * brand + name 텍스트 → 향수 노트·설명 생성 (LLM 향수 지식 활용).
+ * - gpt-4o-mini로 비용 최소화 ($0.0001/호출)
+ * - JSON 응답으로 안전 파싱
+ * - LLM이 모르는 향수면 빈 응답 (hallucination 방지 프롬프트)
+ */
+
+export interface EnrichedInfo {
+  description: string;
+  notes: string;
+  englishSlug: string; // LLM이 생성한 영문 표준 slug (잘 모르면 "")
+  confident: boolean; // LLM이 이 향수를 안다고 확신하는지
+  tokensUsed: number;
+}
+
+// 등록 폼용 — 확실한 정보만 반환
+const ENRICH_SYSTEM = `당신은 향수 전문가입니다. 사용자가 식별한 향수 정보(브랜드 + 이름)를 받아, 당신의 향수 지식에 기반해 한국어로 설명과 노트를 제공합니다.
+
+중요:
+- 잘 아는 향수만 정보를 제공하세요. 모르거나 확신 없으면 모든 필드를 빈 문자열로 두고 "confident": false 반환.
+- hallucination 금지. 추측한 정보는 빈 문자열.
+- 정보가 정확하면 "confident": true.`;
+
+const ENRICH_USER_TEMPLATE = (brand: string, name: string) => `다음 향수에 대해 알려주세요:
+
+브랜드: ${brand}
+향수명: ${name}
+
+JSON 형식으로만 응답하세요:
+{
+  "confident": true/false (이 향수가 어떤 것인지 정확히 안다면 true, 추측이면 false),
+  "englishSlug": "이 향수의 표준 영문 slug (소문자 + 밑줄). 예시: 'dior_sauvage', 'chanel_no5_leau', 'diptyque_philosykos', 'jomalone_lime_basil_mandarin'. 잘 모르면 빈 문자열.",
+  "description": "잘 안다면 2~3 문장 한국어 설명 (계열·분위기·어울리는 상황). 잘 모르면 빈 문자열.",
+  "notes": "잘 안다면 'TOP: ..., HEART: ..., BASE: ...' 형식 한국어. 잘 모르면 빈 문자열."
+}
+
+englishSlug 규칙:
+- 영문 소문자만, 단어 사이 밑줄 (_)
+- 특수문자·공백 모두 밑줄로 변환
+- 브랜드명과 향수명을 영문 표기로 (입력이 한글이어도 영문 변환)
+- 알려진 향수면 표준 영문 이름 사용 (예: "오 소바쥬" 입력 → "sauvage")
+- 모르는 향수면 빈 문자열 (코드가 fallback 처리)`;
+
+// 스캔 결과용 — 항상 최선을 다해 생성
+const SCAN_ENRICH_SYSTEM = `당신은 향수 전문가입니다. 브랜드와 향수명을 받아 한국어로 설명과 노트를 반드시 작성합니다.
+
+규칙:
+- 해당 향수를 알고 있다면 정확한 정보를 작성하세요.
+- 정확히 모르더라도 브랜드 성향·향수명·계열을 근거로 합리적인 설명을 작성하세요. 빈 값은 허용하지 않습니다.
+- description: 계열, 분위기, 어울리는 상황을 2~3문장 한국어로.
+- notes: 'TOP: ...\nHEART: ...\nBASE: ...' 형식 한국어로.`;
+
+const SCAN_ENRICH_USER_TEMPLATE = (brand: string, name: string) => `다음 향수의 설명과 노트를 작성해 주세요:
+
+브랜드: ${brand}
+향수명: ${name}
+
+JSON 형식으로만 응답하세요:
+{
+  "confident": true/false,
+  "englishSlug": "표준 영문 slug (소문자 + 밑줄). 모르면 빈 문자열.",
+  "description": "2~3문장 한국어 설명 (계열·분위기·어울리는 상황). 반드시 작성.",
+  "notes": "TOP: ...\\nHEART: ...\\nBASE: ... 형식 한국어. 반드시 작성."
+}`;
+
+export async function enrichFragranceInfo(
+  brand: string,
+  name: string,
+  options?: { generateAlways?: boolean },
+): Promise<EnrichedInfo> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY missing");
+
+  if (!brand || !name) {
+    return {
+      description: "",
+      notes: "",
+      englishSlug: "",
+      confident: false,
+      tokensUsed: 0,
+    };
+  }
+
+  const forScan = options?.generateAlways === true;
+  const systemPrompt = forScan ? SCAN_ENRICH_SYSTEM : ENRICH_SYSTEM;
+  const userPrompt = forScan
+    ? SCAN_ENRICH_USER_TEMPLATE(brand, name)
+    : ENRICH_USER_TEMPLATE(brand, name);
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+      response_format: { type: "json_object" },
+      max_tokens: 700,
+      temperature: 0.3,
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    console.error(`[enrichInfo] API ${res.status}: ${errBody.slice(0, 200)}`);
+    return {
+      description: "",
+      notes: "",
+      englishSlug: "",
+      confident: false,
+      tokensUsed: 0,
+    };
+  }
+
+  const data = (await res.json()) as {
+    choices: { message: { content: string | null } }[];
+    usage?: { total_tokens?: number };
+  };
+  const content = data.choices[0]?.message?.content;
+  if (!content) {
+    console.error("[enrichInfo] empty content");
+    return {
+      description: "",
+      notes: "",
+      englishSlug: "",
+      confident: false,
+      tokensUsed: 0,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as {
+      confident?: boolean;
+      description?: string;
+      notes?: string;
+      englishSlug?: string;
+    };
+    return {
+      confident: Boolean(parsed.confident),
+      description: String(parsed.description ?? "").trim(),
+      notes: String(parsed.notes ?? "").trim(),
+      englishSlug: sanitizeSlug(String(parsed.englishSlug ?? "")),
+      tokensUsed: data.usage?.total_tokens ?? 0,
+    };
+  } catch (parseErr) {
+    console.error("[enrichInfo] JSON parse failed:", parseErr, "content:", content);
+    return {
+      description: "",
+      notes: "",
+      englishSlug: "",
+      confident: false,
+      tokensUsed: 0,
+    };
+  }
+}
+
+/**
+ * LLM 출력 slug를 안전한 형식으로 정리 (LLM이 가끔 대문자·공백·하이픈 섞음).
+ */
+function sanitizeSlug(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}

--- a/next-server/src/app/lib/scan/findMatch.ts
+++ b/next-server/src/app/lib/scan/findMatch.ts
@@ -1,0 +1,174 @@
+import prisma from "@/prisma/db";
+
+export interface MatchedFragrance {
+  slug: string;
+  brand: string;
+  name: string;
+  images: string[];
+  description: string;
+  notes: string | null;
+  confidence: number; // 0-100
+}
+
+/**
+ * 한/영 brand alias 사전 — 점진적 확장.
+ * AI가 "Christian Dior", "디올" 등으로 추출해도 같은 canonical id로 정규화.
+ */
+const BRAND_ALIASES: Record<string, string[]> = {
+  dior: ["dior", "디올", "christian dior", "크리스챤디올", "크리스천디올"],
+  chanel: ["chanel", "샤넬"],
+  jomalone: ["jomalone", "jomalonelondon", "jo malone", "조말론", "조 말론"],
+  byredo: ["byredo", "바이레도"],
+  diptyque: ["diptyque", "딥디크"],
+  tomford: ["tomford", "tom ford", "톰포드"],
+  prada: ["prada", "프라다"],
+  tamburins: ["tamburins", "탬버린즈", "tamburin"],
+  hermes: ["hermes", "hermès", "에르메스"],
+  sergelutens: ["sergelutens", "serge lutens", "세르주뤼땅"],
+  fredericmalle: ["fredericmalle", "frederic malle", "프레데릭말"],
+  acquadiparma: ["acquadiparma", "acqua di parma", "아쿠아디파르마"],
+  ateliercologne: ["ateliercologne", "atelier cologne", "아틀리에코롱"],
+  lelabo: ["lelabo", "le labo", "르라보"],
+  bykilian: ["bykilian", "by kilian", "바이킬리언", "킬리언"],
+  lanvin: ["lanvin", "랑방"],
+  heeley: ["heeley", "힐리"],
+  commedesgarcons: ["commedesgarcons", "comme des garçons", "comme des garcons", "꼼데가르송"],
+  escentricmolecules: ["escentricmolecules", "escentric molecules"],
+  artisanparfumeur: ["lartisanparfumeur", "l'artisan parfumeur", "랄띠장빠르푸뫼흐"],
+  maisonfranciskurkdjian: ["maisonfranciskurkdjian", "maison francis kurkdjian", "메종프란시스커정"],
+};
+
+// 매칭 임계값 — brand만 일치하고 name이 거의 다른데 추천되는 문제를 막기 위해 상향.
+//  - MIN_CONFIDENCE: 총점(brand 50 + name 50). 70 미만이면 "잘못된 추천" 위험.
+//  - MIN_NAME_SCORE_RAW: name token 매칭 원점수(0-100). 50 미만이면 다른 라인업으로 간주.
+//    예) Dior Sauvage 스캔 → DB의 Dior J'adore와 brand=50 매칭되더라도
+//        name token 0% → 게이트에서 reject되어 null 반환.
+const MIN_CONFIDENCE = 70;
+const MIN_NAME_SCORE_RAW = 50;
+
+function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[°&\-_'·,.\s]/g, "")
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "");
+}
+
+function canonicalBrand(input: string): string {
+  const n = normalize(input);
+  for (const [canonical, aliases] of Object.entries(BRAND_ALIASES)) {
+    const hit = aliases.some((a) => {
+      const na = normalize(a);
+      return na === n || n.includes(na) || na.includes(n);
+    });
+    if (hit) return canonical;
+  }
+  return n;
+}
+
+/**
+ * 영문/한글 토큰화. 너무 짧은 토큰(≤1)은 노이즈로 제외.
+ */
+function tokenize(s: string): string[] {
+  return normalize(s)
+    .replace(/([a-z0-9]+)/g, " $1 ")
+    .split(/\s+/)
+    .filter((t) => t.length >= 2);
+}
+
+/**
+ * 양방향 token 매칭 점수 (0-100).
+ * matches / max(aTokens, bTokens) — 짧은 쪽이 다 매칭돼도 긴 쪽 손실 반영.
+ */
+function nameMatchScore(a: string, b: string): number {
+  const aTokens = tokenize(a);
+  const bTokens = tokenize(b);
+  if (aTokens.length === 0 || bTokens.length === 0) return 0;
+
+  let matches = 0;
+  for (const at of aTokens) {
+    if (bTokens.some((bt) => bt === at || bt.includes(at) || at.includes(bt))) {
+      matches++;
+    }
+  }
+  return (matches / Math.max(aTokens.length, bTokens.length)) * 100;
+}
+
+/**
+ * brand+name으로 자체 갤러리 fuzzy 매칭. 점수 ≥ 50만 반환.
+ * - brand canonical 일치 또는 부분 포함
+ * - name token 매칭
+ * - 41건 풀스캔 (1000건+ 시 SQL 인덱스 활용으로 변경 필요)
+ */
+export async function findFragranceMatch(
+  aiBrand: string,
+  aiName: string,
+): Promise<MatchedFragrance | null> {
+  if (!aiBrand || !aiName) return null;
+
+  const aiCanonical = canonicalBrand(aiBrand);
+
+  const fragrances = await prisma.fragrance.findMany({
+    select: {
+      slug: true,
+      brand: true,
+      name: true,
+      images: true,
+      description: true,
+      notes: true,
+    },
+  });
+
+  let best: MatchedFragrance | null = null;
+  let bestScore = 0;
+  let bestNameRaw = 0;
+
+  for (const f of fragrances) {
+    const dbCanonical = canonicalBrand(f.brand);
+
+    // Brand 점수 (50점 만점)
+    let brandScore: number;
+    if (dbCanonical === aiCanonical) {
+      brandScore = 50;
+    } else if (
+      normalize(f.brand).includes(normalize(aiBrand)) ||
+      normalize(aiBrand).includes(normalize(f.brand))
+    ) {
+      brandScore = 30;
+    } else {
+      continue; // brand 매칭 0 → 건너뛰기
+    }
+
+    // Name 점수 — 원점수(0-100)와 가중(50점) 분리 보관
+    const nameScoreRaw = nameMatchScore(aiName, f.name);
+    const nameScore = nameScoreRaw * 0.5;
+
+    const total = brandScore + nameScore;
+    if (total > bestScore) {
+      bestScore = total;
+      bestNameRaw = nameScoreRaw;
+      best = {
+        slug: f.slug,
+        brand: f.brand,
+        name: f.name,
+        images: f.images,
+        description: f.description,
+        notes: f.notes,
+        confidence: Math.round(total),
+      };
+    }
+  }
+
+  // 게이트 1: name 자체가 약하면 reject — brand만 같은 다른 라인업 추천 차단
+  if (bestNameRaw < MIN_NAME_SCORE_RAW) {
+    if (best) {
+      console.log(
+        `[findMatch] reject "${aiBrand} ${aiName}" → "${best.brand} ${best.name}" (nameRaw=${bestNameRaw.toFixed(0)} < ${MIN_NAME_SCORE_RAW})`,
+      );
+    }
+    return null;
+  }
+  // 게이트 2: 총점 게이트
+  if (bestScore < MIN_CONFIDENCE) return null;
+  return best;
+}

--- a/next-server/src/app/lib/scan/findSimilarFragrances.ts
+++ b/next-server/src/app/lib/scan/findSimilarFragrances.ts
@@ -1,0 +1,191 @@
+import prisma from '@/prisma/db';
+
+export interface SimilarFragrance {
+  slug: string;
+  brand: string;
+  name: string;
+  images: string[];
+  description: string;
+  notes: string | null;
+  similarity: number; // 0~1
+  method: 'score' | 'notes';
+}
+
+/**
+ * notes 문자열에서 핵심 키워드 추출.
+ *
+ * 지원 형식:
+ *   - 구조화: "Top Notes: bergamot, lime\nMiddle: rose\nBase: sandalwood"
+ *   - 한글: "탑 노트: 베르가못\n미들: 로즈\n베이스: 샌달우드"
+ *   - 단순 나열: "bergamot, rose, sandalwood, musk"
+ *
+ * 레이블(Top/Middle/Base 등)은 제거하고 실제 향 이름만 반환.
+ * 3자 미만 토큰은 노이즈로 제거 (한글 2자는 유지).
+ */
+function extractNoteKeywords(notes: string): string[] {
+  const cleaned = notes
+    .toLowerCase()
+    // 구조 레이블 제거
+    .replace(
+      /\b(top|middle|base|heart|opening|dry\s*down)\s*(notes?)?\s*:?\s*/gi,
+      '',
+    )
+    .replace(
+      /(탑|미들|베이스|하트|오프닝|드라이다운)\s*(노트)?\s*:?\s*/g,
+      '',
+    );
+
+  return cleaned
+    .split(/[,\n\r;·•]+/)
+    .map((k) => k.replace(/[-_/]/g, ' ').trim())
+    .filter((k) => {
+      if (!k) return false;
+      // 한글 포함이면 2자 이상, 영문만이면 3자 이상
+      const hasKorean = /[가-힣]/.test(k);
+      return hasKorean ? k.length >= 2 : k.length >= 3;
+    });
+}
+
+/**
+ * Jaccard 유사도: |A ∩ B| / |A ∪ B|
+ * 부분 매칭 허용 (substring 포함이면 매칭으로 간주).
+ * 예) "bergamot" ∩ "bergamot" → 매칭 ✓
+ *     "rosy" ∩ "rose" → 부분 포함 → 매칭 ✓
+ */
+function jaccardSimilarity(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const setA = new Set(a);
+  const setB = new Set(b);
+
+  let intersection = 0;
+  for (const ka of setA) {
+    for (const kb of setB) {
+      if (ka.includes(kb) || kb.includes(ka)) {
+        intersection++;
+        break;
+      }
+    }
+  }
+
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * 5차원 유클리디안 유사도 (0~1).
+ * [0,1]^5 공간에서 최대 거리는 √5 ≈ 2.236.
+ * similarity = 1 - distance / maxDistance
+ */
+function scoreSimilarity(
+  a: [number, number, number, number, number],
+  b: [number, number, number, number, number],
+): number {
+  const maxDist = Math.sqrt(5);
+  const dist = Math.sqrt(a.reduce((sum, ai, i) => sum + (ai - b[i]) ** 2, 0));
+  return Math.max(0, 1 - dist / maxDist);
+}
+
+/**
+ * 갤러리에서 비슷한 느낌의 향수 top N 추출.
+ *
+ * 우선순위:
+ *   1) scoreA~E 5차원 거리 (matchedSlug 있고 source + 후보 모두 5점수 보유 시)
+ *   2) notes Jaccard (notes 있을 때 항상 시도)
+ *   두 방법 모두 가능하면 평균. 한 방법만 가능하면 그것만 사용.
+ *
+ * matchedSlug가 없는 경우(갤러리 미등록 향수):
+ *   - sourceNotes만으로 Jaccard fallback 시도.
+ */
+export async function findSimilarFragrances(
+  matchedSlug: string | null,
+  sourceNotes: string | null,
+  limit = 10,
+): Promise<SimilarFragrance[]> {
+  const all = await prisma.fragrance.findMany({
+    select: {
+      slug: true,
+      brand: true,
+      name: true,
+      images: true,
+      description: true,
+      notes: true,
+      scoreA: true,
+      scoreB: true,
+      scoreC: true,
+      scoreD: true,
+      scoreE: true,
+    },
+  });
+
+  const source = matchedSlug ? all.find((f) => f.slug === matchedSlug) ?? null : null;
+  const candidates = all.filter((f) => f.slug !== matchedSlug);
+
+  if (candidates.length === 0) return [];
+
+  // source의 5차원 점수 (모두 있어야 사용)
+  const sourceScores: [number, number, number, number, number] | null =
+    source?.scoreA != null &&
+    source.scoreB != null &&
+    source.scoreC != null &&
+    source.scoreD != null &&
+    source.scoreE != null
+      ? [source.scoreA, source.scoreB, source.scoreC, source.scoreD, source.scoreE]
+      : null;
+
+  // source의 notes 키워드 (matchedSlug의 notes 우선, 없으면 scanResult notes)
+  const notesStr = source?.notes ?? sourceNotes;
+  const sourceKeywords = notesStr ? extractNoteKeywords(notesStr) : [];
+
+  const scored = candidates
+    .map((f) => {
+      const scores: [number, number, number, number, number] | null =
+        f.scoreA != null &&
+        f.scoreB != null &&
+        f.scoreC != null &&
+        f.scoreD != null &&
+        f.scoreE != null
+          ? [f.scoreA, f.scoreB, f.scoreC, f.scoreD, f.scoreE]
+          : null;
+
+      const candidateKeywords = f.notes ? extractNoteKeywords(f.notes) : [];
+
+      // 두 방법 각각 계산
+      const scoreSim =
+        sourceScores && scores ? scoreSimilarity(sourceScores, scores) : null;
+      const notesSim =
+        sourceKeywords.length > 0 && candidateKeywords.length > 0
+          ? jaccardSimilarity(sourceKeywords, candidateKeywords)
+          : null;
+
+      let similarity = 0;
+      let method: 'score' | 'notes' = 'notes';
+
+      if (scoreSim !== null && notesSim !== null) {
+        // 둘 다 있으면 가중 평균 (score 60 : notes 40)
+        similarity = scoreSim * 0.6 + notesSim * 0.4;
+        method = 'score';
+      } else if (scoreSim !== null) {
+        similarity = scoreSim;
+        method = 'score';
+      } else if (notesSim !== null) {
+        similarity = notesSim;
+        method = 'notes';
+      }
+
+      return {
+        slug: f.slug,
+        brand: f.brand,
+        name: f.name,
+        images: f.images,
+        description: f.description,
+        notes: f.notes,
+        similarity,
+        method,
+      };
+    })
+    .filter((f) => f.similarity > 0)
+    .sort((a, b) => b.similarity - a.similarity)
+    .slice(0, limit);
+
+  return scored;
+}

--- a/next-server/src/app/lib/scan/naverShopping.ts
+++ b/next-server/src/app/lib/scan/naverShopping.ts
@@ -1,0 +1,1029 @@
+import { transliterateNameToKorean } from './transliterate';
+import prisma from '@/prisma/db';
+
+/**
+ * 네이버 쇼핑 검색 API (https://developers.naver.com/docs/serviceapi/search/shopping/shopping.md)
+ * - 무료 25,000건/일
+ * - sort=sim (정확도순) — 네이버 자체 랭킹(인기·판매·매칭정확도)으로 정품 인기 상품 상위 노출
+ * - 가격 절대값 게이트 없음 (저렴한 정품 미니/디스커버리/저렴 브랜드를 살리기 위함)
+ *
+ * 다층 정품 신호 (가격 의존 X):
+ *  1) [필수 차단] 샘플/디캔트/짝퉁 키워드 — 명백한 비정품
+ *  2) [필수 차단] 1~15ml 소분 사이즈
+ *  3) [필수 차단] per-ml 단가 ≥ ₩500 (정품 평균 ₩1,500~3,000/ml — 명백 가짜만 컷)
+ *  4) [필수 차단] 향수 카테고리 매칭 — 옷·가방 등 자동 제거
+ *  5) [정렬 우대] 신뢰 점수 = 화이트리스트 mall(30점) + 향수 카테고리(20점)
+ *                          + productType=2(20점) + 단가 정상범위(10~20점)
+ *
+ * 신뢰 점수 가중치 설계:
+ *  - 화이트리스트 mall(+30): 사람이 검증한 mall — 가장 강한 정품 신호
+ *  - 향수 카테고리(+20): mall이 향수로 분류 — 일반 종합몰의 향수도 정상 평가
+ *  - productType=2(+20): 네이버 자동 카탈로그 매핑 — 중간 신호 (catalog 페이지가
+ *    비활성/매핑해제되는 케이스가 많아 +50→+20으로 강등)
+ *  - per-ml 단가(+10~20): 보조 신호
+ *
+ * URL 정책:
+ *  1) item.link (네이버 공식 deeplink) → 원본 mall 상품 페이지 (가장 안정적)
+ *  2) link 없으면 → 검색 URL (최후 fallback)
+ *  - catalog URL은 비활성/매핑 해제 빈번해서 사용 안 함 (productType=2여도)
+ *  - productType=2는 URL이 아니라 신뢰 점수·배지 계산에만 활용
+ */
+
+export type TrustBadge = 'verified_catalog' | 'department' | 'official' | 'beauty_store';
+
+/**
+ * 네이버 쇼핑 API의 productType (https://developers.naver.com/docs/serviceapi/search/shopping/shopping.md):
+ *   '1' = 일반 mall 상품 (productId는 mall 상품 ID — catalog URL로 가면 404)
+ *   '2' = 가격비교 카탈로그 상품 (productId가 진짜 catalog ID — catalog URL 작동)
+ *   '3' = 가격비교 비매칭
+ *   '4' = 중고
+ */
+export type NaverProductType = '1' | '2' | '3' | '4';
+
+/**
+ * 검색 결과 정렬 모드:
+ *  - 'price' : 신뢰 tier 내 최저가 순 → 가격 비교 (기본값)
+ *  - 'trust' : 배지 우선순위 → trustScore 순 → 신뢰 스토어 추천 (가격 무시)
+ *
+ * 'trust' 모드 추가 동작:
+ *  - 병행수입 상품 차단 (공식 국내 유통만 허용)
+ *  - 뷰티 전문몰(올리브영·시코르) > 백화점 > 공식몰 > 나머지 순으로 정렬
+ */
+export type SearchMode = 'price' | 'trust';
+
+/** 응답 productType이 알려진 값인지 확인 (그 외엔 undefined로 처리). */
+function isKnownProductType(v: string | undefined): v is NaverProductType {
+  return v === '1' || v === '2' || v === '3' || v === '4';
+}
+
+export interface NaverShoppingItem {
+  source: 'naver';
+  mall: string;
+  price: number;
+  url: string;
+  title: string;
+  thumbnail: string;
+  size: string | null;
+  productId?: string;
+  /** 네이버 productType (UI 배지·정렬 우대용) */
+  productType?: NaverProductType;
+  /** per-ml 단가 (원). size 모르면 null */
+  pricePerMl: number | null;
+  /** 다층 신호 합산 신뢰 점수 (0-100). 높을수록 정품 가능성 ↑ */
+  trustScore: number;
+  /** UI에 표시할 신뢰 배지 (복수 가능) */
+  badges: TrustBadge[];
+}
+
+/**
+ * 내부 처리용 확장 type — 필터·로그 단계에서 정규식 결과 재사용을 위함.
+ * 외부 API 응답에는 노출하지 않음 (return 직전 strip).
+ */
+type InternalNaverItem = NaverShoppingItem & {
+  _hasFragranceCat: boolean;
+  _categoryPath: string;
+};
+
+const NAVER_API = 'https://openapi.naver.com/v1/search/shop.json';
+const TIMEOUT_MS = 5000;
+// 네이버 API 최대값 100. brand.naver.com 같은 공식 스토어가 30위 밖일 수 있어
+// 풀을 최대로 늘려서 필터링 후 상위 N개 반환. 응답 약간 무거워지지만 체감 차이 적음.
+const FETCH_COUNT = 100;
+
+// 상세 디버그 로그 토글 — 운영 환경에선 false (콘솔 시끄러움 방지),
+// 개발·진단 시 SCAN_DEBUG=1로 활성. 핵심 한 줄(summary) 로그는 항상 출력.
+const SCAN_DEBUG =
+  process.env.SCAN_DEBUG === '1' || process.env.NODE_ENV !== 'production';
+
+// 샘플·소분·디캔트류 (직접적인 비정품 신호). 매 검사 시 toLowerCase() 회피 위해
+// 모듈 로드 시 미리 소문자로 정규화 (한국어는 대소문자 영향 없지만 일관성을 위해).
+const SAMPLE_KEYWORDS_LOWER = [
+  '샘플', '시향', '시향지', '시향노트',
+  '디캔트', '디캔', '디켄트',
+  '테스터', '테스타', 'tester',
+  '소분', '소량', '분할', '분배', '용량분배', '용량소분',
+  '분증', '분해', '분주',
+  '미니어처', '미니어쳐', '미니',
+  '트래블', '트라벨', '트레블', 'travel',
+  '공병', '리필', '리필용',
+  '휴대용', '휴대',
+].map((k) => k.toLowerCase());
+
+// 짝퉁·이미테이션·비공식 유통 키워드 (비정품·해외 비공식 신호)
+const IMITATION_KEYWORDS_LOWER = [
+  '짝퉁', '이미테이션', '이미타시옹',
+  '인스파이어', '인스파이어드', 'inspired',
+  '유사향', '유사', '비슷한향', '비슷한',
+  '미러', 'mirror',
+  '복제', '모방',
+  'dupe', 'duplicate',
+  '카피향', '카피',
+  '저렴이', '저렴한',
+  '대체향', '대체',
+  // 병행수입은 SearchMode='trust' 일 때만 차단 (가격 비교에서는 허용)
+  // → runSingleSearch filterParallelImport 파라미터로 처리
+].map((k) => k.toLowerCase());
+
+// 1~15ml 소분 사이즈 (정품 최소가 보통 30ml 이상)
+const SMALL_SIZE_REGEX = /(?:^|[^\d])(1|1\.5|2|2\.5|3|4|5|6|7|7\.5|8|9|10|12|15)\s*ml\b/i;
+
+// oz 소분 사이즈 — 0.x oz는 전부 샘플/미니 (0.33 oz ≈ 10ml, 0.5 oz ≈ 15ml)
+// 1 oz ≈ 30ml도 미니이지만 허용; 0.x oz만 차단
+const SMALL_SIZE_OZ_REGEX = /(?:^|[^\d])0\.\d{1,2}\s*(?:fl\.?\s*)?oz\b/i;
+
+// per-ml 단가 하한 — 정품은 보통 ₩1,500~3,000/ml. ₩500 미만은 명백히 가짜·소분 의심.
+// (size 추출 못 하면 이 게이트는 건너뜀)
+const MIN_PRICE_PER_ML = 500;
+// per-ml 단가 정상 범위 — 신뢰 점수 가산 기준
+const NORMAL_PRICE_PER_ML = 1_000;
+
+/**
+ * 신뢰할 수 있는 mall 화이트리스트 (mallName이 포함하면 매칭).
+ *
+ * 정책: **검증된 mall 패턴만 유지**. generic 키워드(/공식|오피셜|official/) 같은
+ * 자유 텍스트 매칭은 mall이 자기 이름에 임의로 그 단어를 붙이면 자동 통과되므로
+ * 검증 효과가 약함 (예: "듀씨엘 공식 스토어" 같은 미검증 mall도 +30점 받게 됨).
+ *
+ * 추가 기준:
+ *  - 백화점·면세점: 한국에서 공인된 정품 유통 채널
+ *  - 뷰티 전문몰: 시코르·올리브영처럼 공식 입점 검증 채널
+ *  - 브랜드 직영: 도메인이 brand.naver.com인 경우 isOfficialNaverBrandStore로 자동 부여
+ *    (코드에 명시적 브랜드명 패턴은 검증된 것만 유지)
+ */
+const TRUSTED_MALL_PATTERNS: { pattern: RegExp; badge: TrustBadge }[] = [
+  // 백화점 (한국 정품 유통 공인 채널)
+  { pattern: /롯데(닷컴|온|백화점|면세점)?/i, badge: 'department' },
+  { pattern: /현대(Hmall|백화점|면세점|H몰)?/i, badge: 'department' },
+  { pattern: /신세계(몰|백화점|면세점|TV쇼핑)?/i, badge: 'department' },
+  { pattern: /SSG/i, badge: 'department' },
+  { pattern: /갤러리아/i, badge: 'department' },
+  { pattern: /AK(몰|플라자)?/i, badge: 'department' },
+
+  // 면세점 (공인 정품 유통)
+  { pattern: /(신라|롯데|현대|신세계)면세점/i, badge: 'department' },
+
+  // 뷰티·향수 전문몰 (입점 검증 채널)
+  { pattern: /시코르|chicor/i, badge: 'beauty_store' },
+  { pattern: /올리브영|oliveyoung/i, badge: 'beauty_store' },
+  { pattern: /(부띠끄|코스메스토어|비비더비|아리따움|닥터자르트)/i, badge: 'beauty_store' },
+
+  // 브랜드 직영 — 다음 두 가지 신호 합치:
+  //  1) generic "공식/오피셜/official" 단어 (의류 겸업 브랜드는 검증된 mall 풀이 적어,
+  //     이 패턴이 정렬에 필요. URL 검증(verifyAndFill)이 빈 페이지 mall을 제거하니
+  //     자유 단어로 점수만 받아도 사용자가 실제로 빈 페이지 만나지 않음)
+  //  2) 명시적 글로벌 브랜드명 (디올·샤넬 등)
+  //  3) brand.naver.com 도메인은 isOfficialNaverBrandStore가 별도로 official 부여
+  { pattern: /공식|오피셜|official/i, badge: 'official' },
+  { pattern: /(dior|chanel|hermes|tom\s*ford|jo\s*malone|byredo|diptyque|le\s*labo)\s*(직영|brand)?/i, badge: 'official' },
+];
+
+function stripHtml(s: string): string {
+  return s.replace(/<\/?[^>]+>/g, '').trim();
+}
+
+function extractSize(title: string): string | null {
+  const ml = title.match(/(\d+(?:\.\d+)?)\s*ml\b/i);
+  if (ml) return `${ml[1]}ml`;
+  const oz = title.match(/(\d+(?:\.\d+)?)\s*(?:fl\.?\s*)?oz\b/i);
+  if (oz) return `${oz[1]}oz`;
+  return null;
+}
+
+/**
+ * 추출된 size 문자열에서 ml 환산값 반환 (oz → ml 변환 포함).
+ * 단가 계산과 소분 크기 게이트에 사용.
+ */
+function extractMlNumber(size: string | null): number | null {
+  if (!size) return null;
+  const ml = size.match(/^(\d+(?:\.\d+)?)\s*ml$/i);
+  if (ml) return parseFloat(ml[1]);
+  const oz = size.match(/^(\d+(?:\.\d+)?)\s*oz$/i);
+  if (oz) return Math.round(parseFloat(oz[1]) * 29.5735); // 1 fl oz = 29.5735 ml
+  return null;
+}
+
+/**
+ * 비정품 의심도 판정 — 키워드/사이즈/단가 3중 게이트 (가격 절대값은 사용 X).
+ * 하나라도 걸리면 true (= 결과에서 제외).
+ *
+ * 정품인데 저렴한 케이스(미니/디스커버리/저렴 브랜드)를 살리기 위해 가격 절대값 게이트 제거.
+ * 대신 per-ml 단가가 명백히 비정상(₩500/ml 미만)이면 차단.
+ */
+function isLikelySample(
+  title: string,
+  price: number,
+  pricePerMl: number | null,
+): boolean {
+  const lower = title.toLowerCase();
+
+  // 1) 샘플·소분·디캔트 키워드 (사전 lowercase로 호출당 변환 절감)
+  if (SAMPLE_KEYWORDS_LOWER.some((k) => lower.includes(k))) return true;
+
+  // 2) 짝퉁·이미테이션 키워드 (별도 — 사용자 신뢰가 핵심)
+  if (IMITATION_KEYWORDS_LOWER.some((k) => lower.includes(k))) return true;
+
+  // 3) 1~15ml 소분 사이즈 (ml) 또는 0.x oz (oz 단위 샘플 — 0.33 oz ≈ 10ml)
+  if (SMALL_SIZE_REGEX.test(title)) return true;
+  if (SMALL_SIZE_OZ_REGEX.test(title)) return true;
+
+  // 4) per-ml 단가 명백 비정상 (size 알 수 있을 때만)
+  if (pricePerMl !== null && pricePerMl < MIN_PRICE_PER_ML) return true;
+
+  // 5) 가격 자체가 비정상 (₩1,000 미만은 거의 확실히 광고/오류)
+  if (price < 1_000) return true;
+
+  return false;
+}
+
+/**
+ * link URL이 네이버 인증 브랜드 공식 스토어(brand.naver.com)인지 판정.
+ *
+ * 왜 강한 신호인가:
+ *  - brand.naver.com 도메인은 네이버와 직접 제휴 계약을 맺은 브랜드만 발급받음
+ *  - smartstore.naver.com은 일반 셀러도 가능 → 신뢰도 다양
+ *  - brand.naver.com은 디올·샤넬·랄프로렌 프래그런스 등 공식 스토어 전용
+ *
+ * mall 이름 매칭(화이트리스트)이 놓치는 케이스를 잡음:
+ *  - mall명이 "랄프로렌 프래그런스" → 화이트리스트에 "랄프"가 없어도
+ *    link 도메인으로 공식몰 인증 가능
+ */
+function isOfficialNaverBrandStore(link: string): boolean {
+  if (!link) return false;
+  try {
+    const url = new URL(link);
+    return url.hostname === 'brand.naver.com' || url.hostname.endsWith('.brand.naver.com');
+  } catch {
+    // URL 파싱 실패 (잘못된 link) → 일반 mall로 취급
+    return false;
+  }
+}
+
+/**
+ * mall 이름 + link 도메인 조합으로 신뢰 배지 반환.
+ *
+ * 두 신호를 합쳐서 평가:
+ *  1) link가 brand.naver.com → 자동 official 배지 (가장 강력)
+ *  2) mallName 패턴 매칭 → 백화점·시코르·올리브영 등 배지
+ *
+ * 두 신호 모두 official 배지를 부여하면 중복 추가 안 함.
+ */
+function getMallBadges(mallName: string, link: string): TrustBadge[] {
+  const badges: TrustBadge[] = [];
+
+  // 1) link 도메인이 네이버 브랜드 공식 스토어 → official
+  if (isOfficialNaverBrandStore(link)) {
+    badges.push('official');
+  }
+
+  // 2) mallName 패턴 매칭 (백화점·뷰티 전문·기타 공식 표기)
+  for (const { pattern, badge } of TRUSTED_MALL_PATTERNS) {
+    if (pattern.test(mallName) && !badges.includes(badge)) {
+      badges.push(badge);
+    }
+  }
+  return badges;
+}
+
+/**
+ * 다층 신호를 합산한 신뢰 점수 (0~100).
+ *  - mall 화이트리스트: +30점 (백화점/면세점/공식몰/뷰티 전문 — 사람이 검증)
+ *  - 카테고리 "향수" 매칭: +20점 (mall이 향수로 분류 — 의류 겸업 브랜드 정품도 정상 평가)
+ *  - productType='2' (가격비교 카탈로그): +20점 (이전 +50에서 강등.
+ *    catalog 페이지가 비활성/매핑해제되는 경우가 많아 강한 신호로 보기 어려움)
+ *  - per-ml 단가 정상 (≥ ₩1,000): +10점
+ *  - per-ml 단가 매우 정상 (≥ ₩2,000): 추가 +10점 (총 +20)
+ *
+ * 의도: 시코르·백화점에 입점하지 않는 브랜드(랄프로렌·캘빈클라인 등 의류 겸업) 향수도
+ * 향수 카테고리 + 단가 정상으로 50점 가까이 받아 정상 노출됨.
+ */
+function calcTrustScore(
+  productType: NaverProductType | undefined,
+  badges: TrustBadge[],
+  categoryIsFragrance: boolean,
+  pricePerMl: number | null,
+): number {
+  let score = 0;
+  if (badges.length > 0) score += 30;
+  if (categoryIsFragrance) score += 20;
+  if (productType === '2') score += 20;
+  if (pricePerMl !== null) {
+    if (pricePerMl >= NORMAL_PRICE_PER_ML) score += 10;
+    if (pricePerMl >= NORMAL_PRICE_PER_ML * 2) score += 10;
+  }
+  return score;
+}
+
+/**
+ * URL 정책 — 항상 item.link (네이버 공식 deeplink) 우선.
+ *
+ * catalog URL을 폐기한 이유:
+ *  - productType=2(가격비교 카탈로그)여도 실제 catalog 페이지가 "상품 정보 없음"으로 뜨는
+ *    경우가 빈번. 카탈로그가 비활성화/만료/매핑 해제됐을 수 있음.
+ *  - mall들이 다 빠진 빈 카탈로그면 사용자가 빈 페이지를 보게 됨.
+ *  - 반면 item.link는 네이버가 만든 공식 deeplink로 mall 상품 페이지에 직행 →
+ *    상품이 살아있는 한 거의 항상 작동.
+ *
+ * productType=2 신호는 URL 라우팅에서 제거되었지만 신뢰 점수/배지에는 그대로 유지
+ * (네이버 카탈로그 매칭 자체는 정품 신호로 여전히 유효).
+ *
+ * 우선순위:
+ *  1) item.link (http 시작) → 원본 mall 상품 페이지
+ *  2) 없으면 → 검색 URL fallback
+ */
+function buildItemUrl(originalLink: string, title: string): string {
+  if (originalLink && originalLink.startsWith('http')) {
+    return originalLink;
+  }
+  return `https://search.shopping.naver.com/search/all?query=${encodeURIComponent(title)}`;
+}
+
+/**
+ * URL이 살아있는지 HEAD 요청으로 검증.
+ *
+ * 설계 결정:
+ *  - HEAD 사용 (GET보다 가벼움, body 안 받음)
+ *  - timeout 3초 (느린 mall이 전체 응답 막지 않게)
+ *  - redirect: 'follow' (mall 사이트가 흔히 리다이렉트 사용)
+ *  - 실패(timeout/예외) 시 true 반환 — 보수적 통과
+ *    이유: HEAD를 차단하는 mall들도 정상 작동하므로, 잘못 죽이는 false negative
+ *    피하는 게 우선. 잘못 통과시키는 false positive는 빈 페이지 노출이지만
+ *    그건 받아들임 (HEAD 차단 mall은 결국 검증 불가능).
+ *
+ *  - 200~399: 살아있음
+ *  - 4xx/5xx: 죽었거나 비활성 → 제외
+ */
+async function checkUrlAlive(url: string): Promise<boolean> {
+  if (!url || !url.startsWith('http')) return false;
+  try {
+    const res = await fetch(url, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(3000),
+      redirect: 'follow',
+    });
+    return res.status >= 200 && res.status < 400;
+  } catch {
+    // timeout, network error, HEAD 차단 등 → 보수적으로 통과 (false negative 회피)
+    return true;
+  }
+}
+
+/**
+ * 신뢰 점수 정렬된 후보 목록에서 URL 검증 통과한 항목만 골라 target개 채움.
+ *
+ *  - 후보를 순서대로 검증, 통과한 것만 result에 추가
+ *  - target개 채워지면 즉시 종료 (불필요한 HEAD 요청 절약)
+ *  - 후보 부족(검증 통과가 target 미만)이면 통과한 것만 반환
+ *
+ * HEAD 요청 병렬화: 한 번에 5개씩 batch로 검증해서 응답 시간 단축.
+ */
+async function verifyAndFill<T extends { url: string }>(
+  candidates: T[],
+  target: number,
+): Promise<T[]> {
+  const result: T[] = [];
+  const batchSize = 5;
+
+  for (let i = 0; i < candidates.length && result.length < target; i += batchSize) {
+    const batch = candidates.slice(i, i + batchSize);
+    const aliveFlags = await Promise.all(batch.map((c) => checkUrlAlive(c.url)));
+
+    for (let j = 0; j < batch.length; j++) {
+      if (result.length >= target) break;
+      if (aliveFlags[j]) result.push(batch[j]);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 향수 카테고리 매칭 패턴 (네이버 응답의 category1~4 중 하나라도 매칭되면 통과).
+ *
+ * 네이버 쇼핑은 향수를 mall에 따라 다양한 경로로 분류:
+ *   - "화장품/미용 > 향수" (대부분)
+ *   - "패션잡화 > 남성향수/여성향수" (일부)
+ *   - "백화점 > 향수" 등
+ *
+ * 의류 카테고리(상의/하의/원피스/셔츠/티셔츠 등)는 자동으로 떨어짐.
+ */
+const FRAGRANCE_CATEGORY_REGEX = /향수|perfume|fragrance|코롱|cologne|오\s*드\s*(퍼퓸|뚜왈렛|뚜왈레)|edp|edt|edc|parfum/i;
+
+/**
+ * 상품 title에서 향수 관련 단서를 찾는 패턴 (positive signal).
+ *
+ * 진짜 향수라면 보통 title에 부향률·"향수"·"perfume" 등 신호가 함께 인쇄됨.
+ * EDP/EDT/EDC는 word boundary로 감싸 "edit", "edition" 같은 단어 오매칭 방지.
+ */
+const TITLE_FRAGRANCE_KEYWORDS_REGEX =
+  /향수|코롱|오\s*드\s*(퍼퓸|뚜왈렛|뚜왈레|코롱)|오드퍼퓸|오드뚜왈렛|perfume|fragrance|cologne|eau\s*de|\bedp\b|\bedt\b|\bedc\b|parfum|extrait/i;
+
+function hasTitleFragranceSignal(title: string): boolean {
+  return TITLE_FRAGRANCE_KEYWORDS_REGEX.test(title);
+}
+
+/**
+ * title에 명백한 비-향수(옷·잡화) 단어가 있으면 차단 (negative signal).
+ *
+ * 이 방식이 "향수 단어 없으면 차단"보다 정확:
+ *  - 정품 누락 위험 거의 없음 (옷 단어가 정품 향수 title에 들어가는 일은 사실상 없음)
+ *  - mall이 카테고리를 옷→향수로 잘못 분류해도 title은 못 속임
+ *  - 예: "Ralph Lauren Polo Shirt" → "shirt" 매칭 → 차단
+ *  - 예: "Ralph Lauren Polo Blue 100ml" → 옷 단어 없음 → 통과
+ *
+ * 의류·잡화 핵심 키워드만 (false positive 최소화).
+ */
+const TITLE_CLOTHING_KEYWORDS_REGEX =
+  /셔츠|\bshirt\b|티셔츠|t-?shirt|폴로\s*셔츠|polo\s*shirt|블라우스|blouse|니트|knit|스웨터|sweater|후드|hoodie|자켓|jacket|점퍼|jumper|코트|\bcoat\b|패딩|padding|조끼|vest|가디건|cardigan|원피스|드레스|\bdress\b|치마|skirt|팬츠|pants|바지|진|jean|반바지|shorts|레깅스|leggings|트레이닝|tracksuit|운동복|가방|\bbag\b|백팩|backpack|크로스백|토트백|tote|클러치|clutch|지갑|wallet|벨트|belt|모자|\bcap\b|\bhat\b|비니|beanie|운동화|sneakers|구두|loafer|로퍼|샌들|sandal|슬리퍼|slipper|부츠|boots|양말|socks|언더웨어|underwear|속옷|brassiere|브래지어|팬티|스카프|scarf|머플러|muffler|장갑|gloves|시계|watch|쥬얼리|jewelry|반지|ring|목걸이|necklace|귀걸이|earring|팔찌|bracelet|선글라스|sunglasses|안경|eyewear/i;
+
+function hasTitleClothingSignal(title: string): boolean {
+  if (!TITLE_CLOTHING_KEYWORDS_REGEX.test(title)) return false;
+
+  // 향수 표지가 같이 있으면 옷 차단하지 않음 — 사은품(가방·파우치) 케이스 false positive 방지
+  //   예: "랄프로렌 향수 폴로67 EDT 125ML +폴로파우치 가방"
+  //     → "가방"이 옷으로 잡히지만 "향수", "EDT"가 분명히 있어 진짜 향수
+  //     → 향수 표지 있으면 옷 차단 무시 → 통과 ✓
+  if (TITLE_FRAGRANCE_KEYWORDS_REGEX.test(title)) return false;
+
+  return true;
+}
+
+/**
+ * 매칭 단계에서 무시할 관사·연결어 (stop words).
+ * mall이 등록한 title에 이런 단어가 빠질 수 있어 매칭 요구에서 제외.
+ *
+ *  예) name="PEACH & TEA" → "and" 자동 분리 → ["peach", "tea"]
+ *      name 한글="피치 앤 티" → "앤" stop으로 제거 → ["피치", "티"]
+ *      → mall title "피치티" / "피치 티" / "피치앤티" 모두 매칭 ✓
+ */
+const MATCH_STOP_WORDS = new Set([
+  '앤', 'and',
+  '의', 'of',
+  '더', 'the',
+  '오브',
+  '인', 'in',
+  '온', 'on',
+]);
+
+/**
+ * 매칭용 정규화 — 띄어쓰기·특수문자 제거 + 소문자.
+ * 같은 단어가 mall마다 다르게 표기되는 차이 흡수.
+ *
+ *  "피치 앤 티"   → "피치앤티"
+ *  "피치 & 티"    → "피치티"
+ *  "PEACH-TEA"   → "peachtea"
+ *  "Polo · 67"   → "polo67"
+ */
+function normalizeForMatch(s: string): string {
+  return s.toLowerCase().replace(/[\s&·\-_/]+/g, '');
+}
+
+/**
+ * title이 검색한 brand 또는 name과 매칭되는지 검증.
+ *
+ * 동기: 네이버 API가 마이너 브랜드(LOE 등)에 그 향수가 없으면 부분 키워드(향수,
+ * 50ml, EDT)로 무관한 향수들을 반환. 우리 신뢰 점수만 보면 그 무관한 향수가
+ * 90점 받고 1위 노출됨. → title 매칭 검증으로 차단.
+ *
+ * 통과 조건 (둘 중 하나):
+ *  - normalize한 title에 normalize한 brand 단어 포함 (3자 이상 brand만)
+ *  - normalize한 title에 name의 **모든 핵심 단어**가 매칭
+ *    (stop words 제외, 2자 이상)
+ *
+ * 표기 차이 흡수 (normalize + stop):
+ *  - 띄어쓰기: "피치 티" vs "피치티" → normalize로 동일
+ *  - 관사: "피치 앤 티" vs "피치 티" → "앤" stop으로 동일
+ *  - 특수문자: "PEACH & TEA" vs "PEACH-TEA" → normalize로 동일
+ *
+ * 예시:
+ *  - "LOE 피치 앤 티" + mall "피치앤티 50ml" → 정상 매칭 ✓
+ *  - "LOE 피치 앤 티" + mall "피치 티 향수" → "앤" stop, 피치·티 모두 매칭 ✓
+ *  - "LOE PEACH & TEA" + mall "Tea Rose" → "peach" 없음 → 제외 ✓
+ *  - "Ralph Lauren Polo 67" + mall "랄프로렌 폴로67 EDT" → polo+67 모두 매칭 ✓
+ *  - "Ralph Lauren Polo 67" + mall "랄프로렌 폴로 블루" → "67" 없음 → 제외 ✓ (다른 모델)
+ */
+function titleMatchesQuery(
+  title: string,
+  brand: string,
+  name: string,
+  koreanName?: string | null,
+): boolean {
+  const titleNorm = normalizeForMatch(title);
+  const brandNorm = normalizeForMatch(brand);
+
+  // brand 매칭 (3자 이상만 — 짧은 brand는 false positive 위험)
+  if (brandNorm.length >= 3 && titleNorm.includes(brandNorm)) return true;
+
+  // name 단어 매칭 시도 (영문 + 한글 변환된 name 둘 다)
+  //  - 영문 mall title은 영문 name 매칭
+  //  - 한글 mall title("폴로67")은 한글 변환 name("폴로 67") 매칭
+  // 둘 중 하나라도 매칭되면 통과 → 영문·한글 mall 모두 잡힘
+  if (matchByNameWords(titleNorm, name)) return true;
+  if (koreanName && matchByNameWords(titleNorm, koreanName)) return true;
+
+  return false;
+}
+
+/**
+ * name의 핵심 단어가 모두 title에 substring으로 있는지 검증.
+ * stop words 제외, 2자 이상 단어만 매칭 필수.
+ */
+function matchByNameWords(titleNorm: string, name: string): boolean {
+  const nameLower = name.toLowerCase().trim();
+  if (!nameLower) return false;
+
+  const nameWords = nameLower
+    .split(/[\s&]+/)
+    .map((w) => w.trim())
+    .filter((w) => w.length >= 2 && !MATCH_STOP_WORDS.has(w));
+  if (nameWords.length === 0) return false;
+
+  return nameWords.every((w) => titleNorm.includes(normalizeForMatch(w)));
+}
+
+/**
+ * 검색 쿼리에서 중복 단어 제거 (대소문자 무시).
+ *
+ * OCR이 brand를 잘못 잡아서 brand+name 합칠 때 중복 발생하는 케이스 대응.
+ *   예) brand="Polo", name="Polo 67" → "Polo Polo 67" → "Polo 67"
+ *   예) brand="랄프로렌", name="랄프로렌 폴로 67" → "랄프로렌 폴로 67"
+ *
+ * brand가 잘못 추출돼도 검색 정확도 유지. 부작용 없음 (중복 단어는 검색에 무익).
+ */
+function dedupeWords(query: string): string {
+  const words = query.split(/\s+/).filter(Boolean);
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const w of words) {
+    const lower = w.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    unique.push(w);
+  }
+  return unique.join(' ');
+}
+
+/**
+ * 검색 쿼리 정규화 — 중복 단어 제거 + "향수" 키워드 보강.
+ * - 의류·잡화 겸업 브랜드의 향수 검색 시 의류 결과 우대 차단
+ * - 이미 "향수/코롱/perfume/fragrance/cologne/eau de" 있으면 추가 안 함
+ */
+function enhanceQueryForFragrance(query: string): string {
+  const deduped = dedupeWords(query);
+  const lower = deduped.toLowerCase();
+  const hasFragranceKeyword =
+    /향수|코롱|perfume|fragrance|cologne|eau\s*de/i.test(lower);
+  return hasFragranceKeyword ? deduped : `${deduped} 향수`;
+}
+
+/**
+ * 단일 검색 라운드 — 네이버 API 호출 + 필터링까지.
+ * 정렬·slice·strip은 상위 호출자(searchNaverShopping)에서 처리.
+ *
+ * 반환 객체에 통계(로그용)와 final passed 리스트 함께 담아 호출자가 1·2차 결과를
+ * 비교·병합하기 쉽게 만듦.
+ */
+interface SearchRoundResult {
+  query: string; // enhance 적용된 실제 쿼리
+  receivedCount: number; // 네이버 API가 반환한 raw item 수
+  passed: InternalNaverItem[]; // 모든 필터 통과 (안전망으로 1차 결과)
+  stats: {
+    afterPrimaryFilter: number; // 키워드/사이즈/단가 통과
+    afterFragranceFilter: number; // 옷·카테고리 통과
+    afterTitleMatch: number; // title이 검색어와 매칭됨
+    rejectedClothing: number;
+    rejectedNonFragranceCategory: number;
+    rejectedTitleMismatch: number;
+  };
+  blockedSamples: string[];
+}
+
+async function runSingleSearch(
+  rawQuery: string,
+  brand: string,
+  name: string,
+  koreanName: string | null = null,
+  filterParallelImport = false,
+): Promise<SearchRoundResult> {
+  const clientId = process.env.NAVER_SHOPPING_CLIENT_ID;
+  const clientSecret = process.env.NAVER_SHOPPING_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error('NAVER_SHOPPING_CLIENT_ID/SECRET missing');
+  }
+
+  const query = enhanceQueryForFragrance(rawQuery);
+  // exclude=used:cbshop — 중고·해외직구를 API 레벨에서 차단 (소스 차단이 가장 확실)
+  const url = `${NAVER_API}?query=${encodeURIComponent(query)}&display=${FETCH_COUNT}&sort=sim&exclude=used:cbshop`;
+
+  const res = await fetch(url, {
+    headers: {
+      'X-Naver-Client-Id': clientId,
+      'X-Naver-Client-Secret': clientSecret,
+    },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Naver Shopping API ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as {
+    items?: {
+      title: string;
+      link: string;
+      image: string;
+      lprice: string;
+      mallName: string;
+      productId?: string;
+      productType?: string;
+      category1?: string;
+      category2?: string;
+      category3?: string;
+      category4?: string;
+    }[];
+  };
+
+  const stats = {
+    afterPrimaryFilter: 0,
+    afterFragranceFilter: 0,
+    afterTitleMatch: 0,
+    rejectedClothing: 0,
+    rejectedNonFragranceCategory: 0,
+    rejectedTitleMismatch: 0,
+  };
+  const blockedSamples: string[] = [];
+
+  if (!data.items || data.items.length === 0) {
+    return { query, receivedCount: 0, passed: [], stats, blockedSamples };
+  }
+
+  // ── parse ──────────────────────────────────────────
+  const allItems: InternalNaverItem[] = data.items
+    .map((item): InternalNaverItem => {
+      const cleanTitle = stripHtml(item.title);
+      const size = extractSize(cleanTitle);
+      const ml = extractMlNumber(size);
+      const price = parseInt(item.lprice, 10);
+      const pricePerMl =
+        ml !== null && ml > 0 && Number.isFinite(price)
+          ? Math.round(price / ml)
+          : null;
+      const badges = getMallBadges(item.mallName, item.link);
+      const productType: NaverProductType | undefined = isKnownProductType(item.productType)
+        ? item.productType
+        : undefined;
+      const categoryPath = [
+        item.category1,
+        item.category2,
+        item.category3,
+        item.category4,
+      ]
+        .filter(Boolean)
+        .join(' > ');
+      const hasFragranceCat =
+        categoryPath.length > 0 && FRAGRANCE_CATEGORY_REGEX.test(categoryPath);
+      const trustScore = calcTrustScore(productType, badges, hasFragranceCat, pricePerMl);
+
+      return {
+        source: 'naver' as const,
+        mall: item.mallName,
+        price,
+        url: buildItemUrl(item.link, cleanTitle),
+        title: cleanTitle,
+        thumbnail: item.image,
+        size,
+        productId: item.productId,
+        productType,
+        pricePerMl,
+        trustScore,
+        badges,
+        _hasFragranceCat: hasFragranceCat,
+        _categoryPath: categoryPath,
+      };
+    })
+    .filter((item) => Number.isFinite(item.price) && item.price > 0 && item.productType !== '4');
+
+  // ── 1차: 키워드/사이즈/단가 게이트 ────────────────
+  const primaryPassed = allItems.filter((item) => {
+    if (isLikelySample(item.title, item.price, item.pricePerMl)) return false;
+    if (filterParallelImport) {
+      // trust 모드: 병행수입 차단 (가격 비교에서는 허용)
+      if (item.title.toLowerCase().includes('병행수입')) return false;
+    }
+    return true;
+  });
+  stats.afterPrimaryFilter = primaryPassed.length;
+
+  // ── 2차: 옷·비-향수 카테고리 차단 (negative signal) ──
+  // 향수명 자체에 의류 단어 포함(e.g. "WHITE SHIRTS", "POLO SHIRT") 시 의류 필터 면제
+  // — 해당 단어가 상품명 일부이므로 셀러 title에 그 단어가 있어도 의류가 아님
+  const nameHasClothingWord =
+    TITLE_CLOTHING_KEYWORDS_REGEX.test(name) ||
+    (koreanName ? TITLE_CLOTHING_KEYWORDS_REGEX.test(koreanName) : false);
+
+  const fragrancePassed = primaryPassed.filter((item) => {
+    if (!nameHasClothingWord && hasTitleClothingSignal(item.title)) {
+      stats.rejectedClothing++;
+      if (blockedSamples.length < 5) {
+        blockedSamples.push(`[옷 title] ${item.mall} | ${item.title.slice(0, 50)}`);
+      }
+      return false;
+    }
+    if (item._categoryPath.length > 0 && !item._hasFragranceCat) {
+      stats.rejectedNonFragranceCategory++;
+      if (blockedSamples.length < 5) {
+        blockedSamples.push(
+          `[비-향수 cat] ${item.mall} | ${item.title.slice(0, 40)} | cat="${item._categoryPath}"`,
+        );
+      }
+      return false;
+    }
+    return true;
+  });
+  stats.afterFragranceFilter = fragrancePassed.length;
+
+  // 3차: title 매칭 검증 — 검색어와 무관한 향수 차단 (마이너 브랜드 케이스 핵심)
+  //   네이버가 "LOE PEACH & TEA" 검색에 "딥티크 오 로즈"를 반환하는 경우 같은
+  //   부분 키워드 매칭 노이즈를 거름. brand 또는 name 단어가 title에 있어야 통과.
+  //   koreanName이 있으면 한글 mall title("폴로67")도 매칭 시도.
+  const titleMatched = fragrancePassed.filter((item) => {
+    if (titleMatchesQuery(item.title, brand, name, koreanName)) return true;
+    stats.rejectedTitleMismatch++;
+    if (blockedSamples.length < 5) {
+      blockedSamples.push(
+        `[title 불일치] ${item.mall} | ${item.title.slice(0, 50)}`,
+      );
+    }
+    return false;
+  });
+  stats.afterTitleMatch = titleMatched.length;
+
+  // title 매칭이 정확도 우선의 마지막 게이트. 0건이면 0건으로 정직 반환.
+  //  - LOE 같은 마이너 브랜드 케이스: 무관한 향수 차단이 핵심 의도
+  //  - 안전망(폴백)을 두면 의도 위반 — 차라리 PriceCards 0건 표시 + 네이버 검색 링크 fallback
+  const passed = titleMatched;
+
+  return { query, receivedCount: allItems.length, passed, stats, blockedSamples };
+}
+
+/**
+ * 두 SearchRoundResult를 병합 — 1차(영문) + 2차(한글) 결과 통합.
+ *  - URL 기준 중복 제거 (1차 우선)
+ *  - 통계는 합산 (디버그용)
+ *  - query는 "1차 | 2차" 형식
+ */
+function mergeRounds(r1: SearchRoundResult, r2: SearchRoundResult): SearchRoundResult {
+  const seenUrls = new Set(r1.passed.map((i) => i.url));
+  const additions = r2.passed.filter((i) => !seenUrls.has(i.url));
+  return {
+    query: `${r1.query} | ${r2.query}`,
+    receivedCount: r1.receivedCount + r2.receivedCount,
+    passed: [...r1.passed, ...additions],
+    stats: {
+      afterPrimaryFilter: r1.stats.afterPrimaryFilter + r2.stats.afterPrimaryFilter,
+      afterFragranceFilter: r1.stats.afterFragranceFilter + r2.stats.afterFragranceFilter,
+      afterTitleMatch: r1.stats.afterTitleMatch + r2.stats.afterTitleMatch,
+      rejectedClothing: r1.stats.rejectedClothing + r2.stats.rejectedClothing,
+      rejectedNonFragranceCategory:
+        r1.stats.rejectedNonFragranceCategory + r2.stats.rejectedNonFragranceCategory,
+      rejectedTitleMismatch:
+        r1.stats.rejectedTitleMismatch + r2.stats.rejectedTitleMismatch,
+    },
+    blockedSamples: [...r1.blockedSamples, ...r2.blockedSamples].slice(0, 5),
+  };
+}
+
+/**
+ * 메인 검색 — brand+name 분리 받아 1회 검색 후 정렬·반환.
+ *
+ * 흐름:
+ *   1) "${brand} ${name}" 쿼리로 네이버 API 호출 (1회만)
+ *   2) 필터링·신뢰 점수 정렬 → 상위 display개 반환
+ *
+ * brand.naver.com 공식 스토어가 API 결과에 없으면 우리가 어떻게 할 수 없음
+ * (네이버 API의 한계). 그 경우는 UI에서 "네이버 쇼핑에서 보기" 링크로 우회 —
+ * buildFallbackSearchUrl가 만든 URL을 응답에 항상 포함.
+ *
+ * 시그너처를 brand+name 분리해서 받는 이유:
+ *  - 호출자(prices route)가 brand/name 따로 갖고 있음
+ *  - 향후 검색 전략 변경(예: brand만으로 fallback) 시 코드 수정 최소화
+ */
+export interface SearchResult {
+  items: NaverShoppingItem[];
+  /**
+   * 한글 변환된 name (LLM 호출 결과). prices route가 naverSearchUrl 생성에 활용.
+   * 변환 실패 또는 입력과 동일하면 null.
+   *
+   * 항상 한글 변환을 시도 — 1차 결과 유무와 무관하게. 사용자가 "네이버 쇼핑에서
+   * 검색하기" 클릭 시 한글로 정확히 검색되도록 (네이버는 띄어쓰기·표기에 민감).
+   */
+  koreanName: string | null;
+}
+
+export async function searchNaverShopping(
+  brand: string,
+  name: string,
+  display = 5,
+  mode: SearchMode = 'price',
+): Promise<SearchResult> {
+  const trimmedBrand = brand.trim();
+  const trimmedName = name.trim();
+  const rawQuery = [trimmedBrand, trimmedName].filter(Boolean).join(' ');
+
+  // 한글 변환 — DB 캐시 우선, 없으면 LLM 호출 후 저장.
+  // (병렬 처리 불가: title 매칭이 koreanName에 의존해서 직렬)
+  let koreanName = '';
+  if (trimmedName) {
+    const cached = await prisma.fragranceKoreanName.findUnique({
+      where: { brand_name: { brand: trimmedBrand, name: trimmedName } },
+    });
+    if (cached) {
+      koreanName = cached.korean;
+    } else {
+      koreanName = await transliterateNameToKorean(trimmedName);
+      if (koreanName) {
+        await prisma.fragranceKoreanName.upsert({
+          where: { brand_name: { brand: trimmedBrand, name: trimmedName } },
+          create: { brand: trimmedBrand, name: trimmedName, korean: koreanName },
+          update: { korean: koreanName },
+        });
+      }
+    }
+  }
+
+  const isTrustMode = mode === 'trust';
+
+  // 1차: 영문 쿼리로 검색 (단 title 매칭은 영문 + 한글 둘 다 시도)
+  let round = await runSingleSearch(
+    rawQuery,
+    trimmedBrand,
+    trimmedName,
+    koreanName || null,
+    isTrustMode,
+  );
+  let koreanRound: SearchRoundResult | null = null;
+
+  // 1차 결과 0건 + 한글 변환 성공 → 2차 한글 쿼리로 재검색
+  if (round.passed.length === 0 && koreanName) {
+    const koreanQuery = [trimmedBrand, koreanName].filter(Boolean).join(' ');
+    koreanRound = await runSingleSearch(
+      koreanQuery,
+      trimmedBrand,
+      koreanName,
+      null, // 이미 한글로 검색했으니 추가 한글 매칭 X
+      isTrustMode,
+    );
+    round = mergeRounds(round, koreanRound);
+  }
+
+  // ── 정렬 ──────────────────────────────────────────────────────────────
+  // 'price' 모드: 신뢰 tier 내 최저가 순 (가격 비교용)
+  //   Tier 0 (trustScore >= 20): 향수 카테고리·카탈로그·신뢰 몰 — 최저가 순
+  //   Tier 1 (trustScore < 20) : 신호 없음 — 후순위
+  //
+  // 'trust' 모드: 배지 우선순위 → trustScore 순 (신뢰 스토어 추천용, 가격 무시)
+  //   뷰티 전문몰(올리브영·시코르) > 백화점 > 공식몰 > verified_catalog > 나머지
+  const MIN_TRUSTED_SCORE = 20;
+
+  // trust 모드에서 배지 종류별 가중치 (높을수록 우선)
+  const TRUST_BADGE_WEIGHT: Partial<Record<TrustBadge, number>> = {
+    beauty_store: 4,
+    department: 3,
+    official: 2,
+    verified_catalog: 1,
+  };
+
+  const sorted = round.passed.sort((a, b) => {
+    if (isTrustMode) {
+      const aBw = Math.max(0, ...a.badges.map((x) => TRUST_BADGE_WEIGHT[x] ?? 0));
+      const bBw = Math.max(0, ...b.badges.map((x) => TRUST_BADGE_WEIGHT[x] ?? 0));
+      if (bBw !== aBw) return bBw - aBw;
+      return b.trustScore - a.trustScore;
+    }
+    // price 모드: tier → 최저가
+    const aTier = a.trustScore >= MIN_TRUSTED_SCORE ? 0 : 1;
+    const bTier = b.trustScore >= MIN_TRUSTED_SCORE ? 0 : 1;
+    if (aTier !== bTier) return aTier - bTier;
+    return a.price - b.price;
+  });
+
+  // URL 검증 + 후보 보충 (link 작동 확인)
+  //  - 신뢰 점수가 높은 순으로 검증
+  //  - 죽은 mall(404 등)은 건너뛰고 다음 후보로 보충
+  //  - display개 채워지면 즉시 종료 → 불필요한 HEAD 절약
+  //  - 첫 스캔만 비용 발생, 두 번째부터는 24h prices 캐시 hit
+  const resultInternal = await verifyAndFill(sorted, display);
+
+  logSearchSummary(round, sorted, resultInternal, koreanRound);
+
+  // 내부 필드 strip + koreanName 함께 반환
+  const items = resultInternal.map(
+    ({ _hasFragranceCat, _categoryPath, ...publicFields }) => publicFields,
+  );
+  return {
+    items,
+    koreanName: koreanName || null,
+  };
+}
+
+/**
+ * 검색 결과 로그.
+ * - 핵심 한 줄은 항상 출력 (수신·통과·검증·반환 4단계 통계)
+ * - SCAN_DEBUG 환경에서: brand store 추적, mall 분포, URL 검증에서 잘린 mall
+ */
+function logSearchSummary(
+  round: SearchRoundResult,
+  sorted: InternalNaverItem[], // 정렬 후 전체 (URL 검증 대상)
+  result: InternalNaverItem[], // 검증 통과한 최종
+  koreanRound: SearchRoundResult | null = null, // 2차 한글 검색 결과 (있을 시)
+): void {
+  console.log(
+    `[naverShopping] query="${round.query}" | 수신=${round.receivedCount} → 옷·cat 통과=${round.stats.afterFragranceFilter} → title 매칭=${round.stats.afterTitleMatch} → URL검증=${result.length}/${sorted.length} → 반환=${result.length}`,
+  );
+  if (koreanRound) {
+    console.log(
+      `  ↳ 1차 0건 → 한글 변환 2차 검색 "${koreanRound.query}" 수신=${koreanRound.receivedCount}, title 매칭=${koreanRound.stats.afterTitleMatch}`,
+    );
+  }
+
+  if (!SCAN_DEBUG) return;
+
+  // brand.naver.com 노출 여부 (네이버 API 한계 모니터링용)
+  const brandStoreItems = round.passed.filter((i) => isOfficialNaverBrandStore(i.url));
+  if (brandStoreItems.length > 0) {
+    const survived = brandStoreItems.filter((i) => result.some((r) => r.url === i.url)).length;
+    console.log(`  brand.naver.com: 수신=${brandStoreItems.length}, 최종노출=${survived}`);
+  } else {
+    console.log(`  brand.naver.com: 수신 0건 → UI 우회 링크(네이버 쇼핑 검색)로 안내`);
+  }
+
+  // 차단 통계 (옷 title / 비-향수 카테고리 / title 검색어 불일치)
+  const { rejectedClothing, rejectedNonFragranceCategory, rejectedTitleMismatch } = round.stats;
+  if (rejectedClothing > 0 || rejectedNonFragranceCategory > 0 || rejectedTitleMismatch > 0) {
+    console.log(
+      `  차단: 옷 title=${rejectedClothing}, 비-향수 cat=${rejectedNonFragranceCategory}, title 불일치=${rejectedTitleMismatch}`,
+    );
+    if (round.blockedSamples.length > 0) {
+      console.log(`  차단 예시:\n    - ${round.blockedSamples.join('\n    - ')}`);
+    }
+  }
+
+  // mall 분포 (2차 통과 시점) — 어떤 mall들이 들어왔는지 한눈에
+  const passedMallCount = countByMall(round.passed);
+  const passedTop = topMalls(passedMallCount, 10);
+  if (passedTop.length > 0) {
+    console.log(`  통과 mall TOP 10: ${formatMallCounts(passedTop)}`);
+  }
+
+  // URL 검증에서 잘린 mall 분포 — 어떤 mall이 죽었는지 추적
+  const finalUrls = new Set(result.map((r) => r.url));
+  const droppedInVerify = sorted.filter((s) => !finalUrls.has(s.url));
+  if (droppedInVerify.length > 0) {
+    const droppedMallCount = countByMall(droppedInVerify);
+    const droppedTop = topMalls(droppedMallCount, 10);
+    console.log(`  URL 검증 잘린 mall TOP 10: ${formatMallCounts(droppedTop)}`);
+  }
+
+  if (result.length > 0) {
+    console.log(
+      `  반환 결과: ${result
+        .map((r) => `[${r.trustScore}점] ${r.mall} | ${r.title.slice(0, 40)}`)
+        .join('\n              ')}`,
+    );
+  }
+}
+
+/** mall명 → 출현 횟수 카운트. */
+function countByMall(items: { mall: string }[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item.mall, (counts.get(item.mall) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Map<mall, count>를 횟수 내림차순 정렬해 상위 N개 반환. */
+function topMalls(counts: Map<string, number>, n: number): [string, number][] {
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
+}
+
+/** 로그용 포맷: "mall×3, mall2×2, ..." */
+function formatMallCounts(top: [string, number][]): string {
+  return top.map(([m, c]) => `${m}×${c}`).join(', ');
+}
+
+/**
+ * 네이버 쇼핑 자체 검색 페이지 URL — 모든 브랜드의 공식 스토어 우회 경로.
+ *
+ * 정책 결정 (매핑 사전 폐기):
+ *  - brand.naver.com 직행 URL은 브랜드별 슬러그 매핑이 필요한데, 슬러그는 우리가
+ *    검증해야 하고 외부에서 만든 카테고리/필터 URL은 네이버가 봇으로 차단.
+ *  - 모든 브랜드를 일관되게 네이버 쇼핑 검색 페이지로 보내고, 네이버 자체 UI에서
+ *    공식 스토어를 우대 노출하도록 위임.
+ *  - 사용자는 2클릭으로 공식 스토어 도달 (우리 → 네이버 검색 → 공식 스토어).
+ *
+ * 중복 단어 제거(dedupe) 적용 — "Polo Polo 67" → "Polo 67"
+ */
+export function buildFallbackSearchUrl(query: string): string {
+  return `https://search.shopping.naver.com/search/all?query=${encodeURIComponent(enhanceQueryForFragrance(query))}`;
+}

--- a/next-server/src/app/lib/scan/rateLimit.ts
+++ b/next-server/src/app/lib/scan/rateLimit.ts
@@ -1,0 +1,48 @@
+/**
+ * In-memory sliding window 레이트 리밋 (분당 5회/key).
+ * Vercel serverless 환경에서는 instance 단위 — 분산 환경에선 한계 있지만
+ * 베타 단계 비용 방어용으로 충분. 운영 확장 시 Redis 검토.
+ */
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 5;
+
+const store = new Map<string, number[]>();
+
+export function checkRateLimit(key: string): {
+  allowed: boolean;
+  remaining: number;
+  resetInMs: number;
+} {
+  const now = Date.now();
+  const timestamps = (store.get(key) ?? []).filter(
+    (t) => now - t < WINDOW_MS,
+  );
+
+  if (timestamps.length >= MAX_REQUESTS) {
+    const oldest = timestamps[0];
+    return {
+      allowed: false,
+      remaining: 0,
+      resetInMs: WINDOW_MS - (now - oldest),
+    };
+  }
+
+  timestamps.push(now);
+  store.set(key, timestamps);
+
+  return {
+    allowed: true,
+    remaining: MAX_REQUESTS - timestamps.length,
+    resetInMs: WINDOW_MS,
+  };
+}
+
+export function getClientKey(req: Request): string {
+  // x-forwarded-for (Vercel) > x-real-ip > fallback
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  const realIp = req.headers.get("x-real-ip");
+  if (realIp) return realIp;
+  return "unknown";
+}

--- a/next-server/src/app/lib/scan/suggestSimilarFragrances.ts
+++ b/next-server/src/app/lib/scan/suggestSimilarFragrances.ts
@@ -1,0 +1,106 @@
+/**
+ * 스캔한 향수의 정보를 바탕으로 비슷한 느낌의 향수 목록을 LLM으로 생성.
+ * - gpt-4o-mini ($0.0001/호출)
+ * - 결과는 ScanResult.naverRecoCache에 24h 캐시 → 반복 호출 없음
+ */
+
+export interface FragranceSuggestion {
+  brand: string;
+  name: string;
+}
+
+const SYSTEM_PROMPT = `당신은 향수 전문가입니다. 주어진 향수와 비슷한 느낌·계열의 향수를 추천합니다.
+
+규칙:
+- 올리브영·시코르·롯데/현대/신세계 백화점·브랜드 공식몰 등 국내 공식 판매처에서 취급하는 향수 우선
+- 국내에서 정식 유통되며 실제로 구매 가능한 향수만 (병행수입·해외직구 제외)
+- 다양한 브랜드에서 선택 (같은 브랜드 반복 금지)
+- 주어진 향수 자체는 제외
+- hallucination 금지 — 확실한 향수만`;
+
+function buildUserPrompt(
+  brand: string,
+  name: string,
+  description: string | null,
+  notes: string | null,
+): string {
+  const lines = [`브랜드: ${brand}`, `향수명: ${name}`];
+  if (notes) lines.push(`노트: ${notes}`);
+  if (description) lines.push(`설명: ${description}`);
+
+  return `다음 향수와 비슷한 느낌의 향수 4개를 추천해주세요.
+
+${lines.join('\n')}
+
+JSON 배열로만 응답하세요 (다른 텍스트 없이):
+[
+  {"brand": "브랜드명", "name": "향수이름"},
+  ...
+]`;
+}
+
+export async function suggestSimilarFragrances(
+  brand: string,
+  name: string,
+  description: string | null,
+  notes: string | null,
+): Promise<FragranceSuggestion[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('[suggestSimilar] OPENAI_API_KEY missing');
+    return [];
+  }
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: buildUserPrompt(brand, name, description, notes) },
+        ],
+        response_format: { type: 'json_object' },
+        max_tokens: 300,
+        temperature: 0.5,
+      }),
+    });
+
+    if (!res.ok) {
+      console.error(`[suggestSimilar] API ${res.status}`);
+      return [];
+    }
+
+    const data = (await res.json()) as {
+      choices: { message: { content: string | null } }[];
+    };
+    const content = data.choices[0]?.message?.content;
+    if (!content) return [];
+
+    // response_format: json_object 는 최상위가 object 여야 해서
+    // LLM이 { "suggestions": [...] } 또는 { "fragrances": [...] } 등으로 감쌀 수 있음
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+
+    // 배열 값을 가진 첫 번째 키를 찾음
+    const arr = Object.values(parsed).find(Array.isArray) as
+      | { brand?: string; name?: string }[]
+      | undefined;
+
+    if (!arr) return [];
+
+    return arr
+      .filter((item) => item.brand && item.name)
+      .map((item) => ({
+        brand: String(item.brand).trim(),
+        name: String(item.name).trim(),
+      }))
+      .slice(0, 5);
+  } catch (err) {
+    console.error('[suggestSimilar] error:', err);
+    return [];
+  }
+}

--- a/next-server/src/app/lib/scan/transliterate.ts
+++ b/next-server/src/app/lib/scan/transliterate.ts
@@ -1,0 +1,122 @@
+/**
+ * 향수 이름 영문 → 한글 음역 변환 (OpenAI LLM).
+ *
+ * 목적: 네이버 쇼핑 API 1차 검색(영문)이 0건일 때, 한글로 등록된 mall title도
+ * 매칭되도록 2차 검색용 한글 쿼리를 생성. 마이너 브랜드(LOE 등) 같은 케이스
+ * 대응.
+ *
+ * 비용:
+ *  - gpt-4o-mini ~$0.0001~0.001/호출
+ *  - max_tokens 100 (짧은 응답만)
+ *  - 1차 검색에 결과 있으면 호출 안 함 → 평균 비용 매우 작음
+ *  - 24h prices 캐시 hit 시도 호출 안 함
+ *
+ * 안전망:
+ *  - LLM 응답 실패/timeout 시 빈 문자열 반환 → 호출자가 2차 검색 건너뜀
+ *  - 변환 결과가 입력과 동일하면 빈 문자열 반환 (무의미한 재검색 방지)
+ */
+
+const OPENAI_API = 'https://api.openai.com/v1/chat/completions';
+const TIMEOUT_MS = 8000;
+
+const SYSTEM_PROMPT = `You are a transliterator for Korean fragrance e-commerce. Convert English perfume names to Korean phonetic spelling (한글 음역) as commonly used by Korean fragrance sellers on Naver Shopping.
+
+Rules:
+- Convert each English word to its standard Korean phonetic spelling.
+- **CRITICAL: Combine all Korean syllables into one word WITHOUT spaces.** Naver Shopping registers fragrance names as single words (e.g., "피치앤티" not "피치 앤 티"). Spaces between Korean characters break search matching.
+- Keep numbers as-is (e.g., "67" stays "67").
+- For ambiguous words, use the most common Korean rendering found in actual Naver perfume listings.
+- Return JSON only.`;
+
+const USER_PROMPT = (name: string) => `Convert this fragrance name to Korean phonetic spelling (no spaces between Korean characters):
+"${name}"
+
+Examples:
+  "Peach & Tea" → "피치앤티"      (NOT "피치 앤 티")
+  "Apple Cotton" → "애플코튼"     (NOT "애플 코튼")
+  "Oud Wood Intense" → "우드인텐스" (NOT "우드 인텐스")
+  "Lime Basil Mandarin" → "라임바질만다린"
+  "Sauvage" → "사베지"
+  "N°5" → "N°5"
+
+Return JSON:
+{
+  "korean": "한글붙여쓰기결과"
+}`;
+
+/**
+ * 한글 글자 사이의 공백만 제거 (영문·숫자는 그대로 유지).
+ * 네이버 검색이 띄어쓰기에 민감해서 "피치 앤 티"는 못 잡고 "피치앤티"만 잡는 케이스 대응.
+ *
+ *  "피치 앤 티"      → "피치앤티"
+ *  "LOE 피치 앤 티"  → "LOE 피치앤티"   (LOE 뒤 공백은 영문 다음이라 유지)
+ *  "apple 코튼 향수"  → "apple 코튼향수" (apple 뒤 공백 유지, 한글-한글 사이만)
+ */
+function removeKoreanSpaces(s: string): string {
+  // lookahead로 "한글 + 공백 + 한글" 패턴의 공백만 제거
+  return s.replace(/([가-힣])\s+(?=[가-힣])/g, '$1');
+}
+
+/**
+ * 향수 영문 이름을 한글 음역으로 변환.
+ *
+ * @returns 변환된 한글 문자열 (한글 사이 공백 제거됨). 변환 실패 또는 입력과 동일하면 빈 문자열.
+ */
+export async function transliterateNameToKorean(name: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.warn('[transliterate] OPENAI_API_KEY missing — skipping');
+    return '';
+  }
+
+  const trimmed = name.trim();
+  if (!trimmed) return '';
+
+  try {
+    const res = await fetch(OPENAI_API, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: USER_PROMPT(trimmed) },
+        ],
+        response_format: { type: 'json_object' },
+        max_tokens: 100,
+        temperature: 0.1,
+      }),
+    });
+
+    if (!res.ok) {
+      console.warn(`[transliterate] API ${res.status} — skipping`);
+      return '';
+    }
+
+    const data = (await res.json()) as {
+      choices: { message: { content: string | null } }[];
+    };
+    const content = data.choices[0]?.message?.content;
+    if (!content) return '';
+
+    const parsed = JSON.parse(content) as { korean?: string };
+    const rawKorean = (parsed.korean ?? '').trim();
+
+    // 후처리 안전망: LLM이 띄어쓰기로 줘도 한글 사이 공백 제거
+    const korean = removeKoreanSpaces(rawKorean);
+
+    // 변환 실패 또는 입력과 동일 → 무의미한 재검색 방지
+    if (!korean || korean === trimmed || korean.toLowerCase() === trimmed.toLowerCase()) {
+      return '';
+    }
+
+    return korean;
+  } catch (err) {
+    console.warn('[transliterate] 실패 — skipping:', err instanceof Error ? err.message : err);
+    return '';
+  }
+}

--- a/next-server/src/app/lib/scan/visionAnalyze.ts
+++ b/next-server/src/app/lib/scan/visionAnalyze.ts
@@ -1,0 +1,284 @@
+/**
+ * 향수 이미지 → 구조화 OCR (brand / name / concentration / size 분리).
+ * 노트·설명은 enrichInfo.ts에서 텍스트 기반으로 별도 생성.
+ *
+ * 2-pass 정확도/비용 균형 설계:
+ *   1) 1차: detail="low" (이미지 토큰 85, 빠르고 쌈)
+ *      대부분의 또렷한 라벨은 여기서 끝남 — 평균 비용 이전과 동일
+ *   2) needsHighResRetry() 평가 → name 결손/너무 짧음/concentration-only 등이면 의심
+ *   3) 2차: detail="high" (이미지 토큰 ~765) — 어려운 케이스(작은 글씨, 흐린 사진)만
+ *
+ * 추출 정확도 보장:
+ *   - 구조화 프롬프트: name 필드에 부향률/용량/원산지가 섞이지 않도록 분리
+ *   - isConcentrationOnly 안전망: LLM이 부향률을 name으로 넣으면 코드에서 차단
+ *   - rawText: 디버깅 + 향후 재구성용 (UI/계약 변경 없이 내부 보유)
+ *
+ * 모델 거부 시 gpt-4o-mini로 자동 fallback (정책 약간 다름, 비용 ~1/30).
+ */
+
+export interface VisionAnalysis {
+  isFragrance: boolean;
+  brand: string;
+  name: string;
+  tokensUsed: number;
+}
+
+const VISION_SYSTEM = `You are an OCR assistant for a personal fragrance gallery app. Users upload their own photos of perfume products to catalog in their personal collection. Your task is to extract visibly printed text from the image — this is text recognition, not identification.`;
+
+const VISION_PROMPT = `This image shows a perfume product photo uploaded by the user for cataloging.
+
+Read the visibly printed text on the bottle/package and return JSON with these fields separated:
+
+{
+  "isFragrance": true if the image shows a perfume/fragrance product (bottle, box, package), false otherwise,
+  "rawText": "All visible text concatenated with ' | ' separators (for debugging). Empty if isFragrance is false.",
+  "brand": "ONLY the maker/house name (e.g. 'Chanel', 'Dior', 'Jo Malone London'). Empty string if not visible. Prefer English/original spelling.",
+  "name": "The specific product/line name (e.g. 'N°5', 'Sauvage', 'Polo Blue', 'Lime Basil & Mandarin', 'Polo 67'). EXCLUDE only: pure concentration words ('Eau de Parfum', 'EDP', 'EDT', 'Parfum', 'Cologne', 'Eau Fraiche'), size/volume ('50ml', '100 ml', '1.7 FL.OZ.', '3.4 oz'), origin ('Paris', 'Made in France'), barcodes, batch codes. Compound names that include a concentration word ARE valid (e.g. 'Polo Cologne Intense', 'Eau Sauvage' — the latter is an actual product name). If a product line number or sub-name is shown (e.g. 'Polo 67', 'Acqua di Giò Profumo'), include it as the name.",
+  "concentration": "Concentration type if visible: 'EDP' | 'EDT' | 'EDC' | 'Parfum' | 'Eau Fraiche' | '' (empty if not visible)",
+  "size": "Volume if visible, e.g. '50ml' | '100ml' | '' (empty if not visible)"
+}
+
+Rules:
+- If isFragrance is false, set all string fields to "".
+- Extract your best reading of the product name. If multiple text fragments could be the name, pick the most prominent one printed near the brand name (often immediately below or beside the brand). Only leave name empty if NO product/line text is visible at all.
+- For brand+name combinations like "POLO 67 RALPH LAUREN": brand="Ralph Lauren", name="Polo 67".
+- Return ONLY valid JSON, no other text.
+- Do NOT refuse — this is text extraction from a product label, not identification of any person.`;
+
+class VisionRefusalError extends Error {
+  constructor(public refusal: string) {
+    super(`Vision refused: ${refusal}`);
+    this.name = "VisionRefusalError";
+  }
+}
+
+type ImageDetail = "low" | "high";
+
+async function callVisionOnce(
+  imageUrl: string,
+  model: string,
+  detail: ImageDetail,
+): Promise<VisionAnalysis> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY missing");
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: "system", content: VISION_SYSTEM },
+        {
+          role: "user",
+          content: [
+            { type: "image_url", image_url: { url: imageUrl, detail } },
+            { type: "text", text: VISION_PROMPT },
+          ],
+        },
+      ],
+      response_format: { type: "json_object" },
+      // rawText + 구조화 필드 5개 포함하므로 600 토큰
+      max_tokens: 600,
+      temperature: 0.1,
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    throw new Error(`Vision API ${res.status}: ${errBody.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as {
+    choices: {
+      message: { content: string | null; refusal?: string | null };
+      finish_reason?: string;
+    }[];
+    usage?: { total_tokens?: number };
+  };
+
+  const choice = data.choices[0];
+  const content = choice?.message?.content;
+
+  if (!content) {
+    console.error(
+      `[visionAnalyze:${model}] empty content. Full response:`,
+      JSON.stringify(data, null, 2),
+    );
+    const reason = choice?.finish_reason ?? "unknown";
+    const refusal = choice?.message?.refusal;
+
+    if (refusal) throw new VisionRefusalError(refusal);
+    if (reason === "content_filter") {
+      throw new VisionRefusalError("정책 차단 (content_filter)");
+    }
+    if (reason === "length") {
+      throw new Error("응답이 잘렸어요. 다시 시도해주세요.");
+    }
+    throw new Error(`Vision API empty response (finish_reason=${reason})`);
+  }
+
+  interface RawVisionResponse {
+    isFragrance?: boolean;
+    rawText?: string;
+    brand?: string;
+    name?: string;
+    concentration?: string;
+    size?: string;
+  }
+
+  let parsed: RawVisionResponse;
+  try {
+    parsed = JSON.parse(content) as RawVisionResponse;
+  } catch {
+    console.error(`[visionAnalyze:${model}] JSON parse failed. content:`, content);
+    throw new Error("Vision 응답을 JSON으로 파싱할 수 없어요.");
+  }
+
+  const brand = String(parsed.brand ?? "").trim();
+  let name = String(parsed.name ?? "").trim();
+  const concentration = String(parsed.concentration ?? "").trim();
+  const rawText = String(parsed.rawText ?? "").trim();
+
+  // 안전망: LLM이 여전히 부향률을 name으로 넣은 경우 제거
+  // 예) name="Eau de Parfum", concentration="" → name을 비움
+  if (name && isConcentrationOnly(name)) {
+    console.warn(
+      `[visionAnalyze:${model}/${detail}] name이 부향률("${name}")로 추출됨 → 비움. rawText="${rawText}"`,
+    );
+    name = "";
+  }
+
+  // 디버깅용: 추출 결과 한 줄 로그 (운영 중 오인식 추적)
+  console.log(
+    `[visionAnalyze:${model}/${detail}] brand="${brand}" name="${name}" conc="${concentration}" raw="${rawText.slice(0, 120)}"`,
+  );
+
+  return {
+    isFragrance: Boolean(parsed.isFragrance),
+    brand,
+    name,
+    tokensUsed: data.usage?.total_tokens ?? 0,
+  };
+}
+
+/**
+ * 부향률·용량 같은 비-제품명 텍스트를 name 후보에서 걸러내기 위한 안전망.
+ * LLM이 프롬프트를 무시하고 "Eau de Parfum"을 name으로 반환하는 경우 차단.
+ */
+function isConcentrationOnly(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/[.\s]/g, "");
+  const blocklist = [
+    "eaudeparfum",
+    "eaudetoilette",
+    "eaudecologne",
+    "eaufraiche",
+    "parfum",
+    "edp",
+    "edt",
+    "edc",
+    "cologne",
+    "extraitdeparfum",
+    "extrait",
+  ];
+  return blocklist.includes(normalized);
+}
+
+/**
+ * 1차 low pass 결과를 보고 "high로 재시도해야 할 정도로 의심스러운가" 판단.
+ *
+ * 안전망(isConcentrationOnly)이 부향률 단어를 빈 값으로 강제 변환하므로,
+ * "name이 비었다" = "low 해상도로는 진짜 제품명을 못 읽었다"는 신호.
+ *
+ * 트리거 조건 (하나라도 만족 시 high 재시도):
+ *  - isFragrance=false: 향수 아닌 사진은 high로 재시도해도 답 없음
+ *  - brand 또는 name이 빈 문자열: 핵심 필드 결손
+ *  - name이 5자 이하: "Polo", "N°5" 같은 짧은 이름은 진짜이긴 한데 잘못 잡혔을 수 있음
+ *    (false positive로 high pass 추가 발생하지만 정확도 우선)
+ *
+ * concentration이 비어있는 경우는 high 재시도 트리거에 넣지 않음 — 향수 라벨에 부향률
+ * 표기가 아예 없는 경우(예: 일부 미니어처)도 있어 false positive 너무 많아짐.
+ */
+function needsHighResRetry(r: VisionAnalysis): boolean {
+  if (!r.isFragrance) return false;
+  if (!r.brand || !r.name) return true;
+  if (r.name.length <= 5) return true;
+  return false;
+}
+
+/**
+ * 모델 거부(refusal) 시 gpt-4o → gpt-4o-mini 자동 fallback.
+ * detail 파라미터를 받아 low/high 양쪽 호출에서 재사용.
+ */
+async function callWithRefusalFallback(
+  imageUrl: string,
+  detail: ImageDetail,
+): Promise<VisionAnalysis> {
+  try {
+    return await callVisionOnce(imageUrl, "gpt-4o", detail);
+  } catch (err) {
+    if (!(err instanceof VisionRefusalError)) throw err;
+    console.warn(
+      `[visionAnalyze] gpt-4o(${detail}) refused (${err.refusal}). Falling back to gpt-4o-mini...`,
+    );
+  }
+  try {
+    return await callVisionOnce(imageUrl, "gpt-4o-mini", detail);
+  } catch (err) {
+    if (err instanceof VisionRefusalError) {
+      throw new Error(
+        "이 사진은 AI가 분석을 거부했어요. 향수병이 또렷이 보이는 다른 각도의 사진으로 시도해주세요. (광고 이미지나 인물이 포함된 사진은 거부될 수 있어요)",
+      );
+    }
+    throw err;
+  }
+}
+
+export async function analyzeFragranceFromUrl(
+  imageUrl: string,
+): Promise<VisionAnalysis> {
+  // 1차 pass: detail="low" — 빠르고 쌈. 대부분 또렷한 라벨은 여기서 끝.
+  const firstPass = await callWithRefusalFallback(imageUrl, "low");
+
+  if (!needsHighResRetry(firstPass)) {
+    return firstPass;
+  }
+
+  // 2차 pass: detail="high" — 작은 글씨/흐린 사진 등 어려운 케이스 보강.
+  // 비용은 약 9배지만 1차에서 걸러진 케이스만 진입하므로 평균 비용 영향 적음.
+  console.log(
+    `[visionAnalyze] 1패스 의심 → high 재시도. 1패스 결과: brand="${firstPass.brand}" name="${firstPass.name}"`,
+  );
+
+  try {
+    const secondPass = await callWithRefusalFallback(imageUrl, "high");
+
+    // high pass도 brand/name이 비면 1차 결과가 더 나쁘진 않으니 1차 유지.
+    // 둘 다 채워졌으면 high 결과 우선 (더 정확).
+    if (secondPass.brand && secondPass.name) {
+      // 토큰 누적: 1차 + 2차 비용을 사용자에게 정확히 보고
+      return {
+        ...secondPass,
+        tokensUsed: firstPass.tokensUsed + secondPass.tokensUsed,
+      };
+    }
+
+    console.log(
+      `[visionAnalyze] high pass도 brand/name 결손 → 1패스 결과 반환`,
+    );
+    return {
+      ...firstPass,
+      tokensUsed: firstPass.tokensUsed + secondPass.tokensUsed,
+    };
+  } catch (err) {
+    // 2차에서 에러나면 1차 결과라도 반환 (전체 실패보단 부분 결과가 나음)
+    console.warn(
+      `[visionAnalyze] high 재시도 실패 → 1패스 결과 반환:`,
+      err instanceof Error ? err.message : err,
+    );
+    return firstPass;
+  }
+}

--- a/next-server/src/app/store/scanPrefillStore.ts
+++ b/next-server/src/app/store/scanPrefillStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+export type ScanPrefill = {
+  brand: string;
+  name: string;
+  description: string;
+  notes: string;
+  imageUrl: string;
+};
+
+type ScanPrefillStore = {
+  prefill: ScanPrefill | null;
+  set: (data: ScanPrefill) => void;
+  clear: () => void;
+};
+
+export const useScanPrefillStore = create<ScanPrefillStore>((setState) => ({
+  prefill: null,
+  set: (data) => setState({ prefill: data }),
+  clear: () => setState({ prefill: null }),
+}));


### PR DESCRIPTION
## Summary

카메라 또는 파일 업로드로 향수 이미지를 인식하고, 가격 비교 및 유사 향수를 추천하는 스캔 기능 전체 구현.

**Pages**
- `/scan` — 카메라·파일 업로드로 향수 이미지 촬영
- `/scan/result/[scanId]` — 인식 결과·가격·유사 향수 표시

**API Routes**
- `POST /api/scan/analyze` — Vision OCR 2-stage 파이프라인 (gpt-4o → enrich)
- `POST /api/scan/enrich` — GPT-4o-mini로 description·notes 보강
- `GET  /api/scan/prices/[scanId]` — 네이버 쇼핑 가격 조회
- `GET  /api/scan/similar/[scanId]` — pgvector 코사인 유사도 기반 갤러리 추천
- `GET  /api/scan/similar/[scanId]/naver` — 네이버 재고 검증된 유사 향수

**Components**
- `CameraCapture`, `FileUploadFallback` — 이미지 입력
- `ScanClient`, `ScanPreview` — 촬영 흐름 UI
- `ScanResult` — 분석 결과 레이아웃
- `PriceCards` — 가격 비교 카드 + 스켈레톤
- `SimilarGallery`, `SimilarNaverReco` — 유사 향수 갤러리

**Libs**
- `visionAnalyze`, `enrichInfo` — Vision OCR 2-stage
- `findMatch`, `findSimilarFragrances`, `suggestSimilarFragrances` — 향수 매칭·추천
- `naverShopping`, `checkNaverAvailability`, `transliterate` — 네이버 연동
- `rateLimit` — 요청 속도 제한

**기타**
- `scanPrefillStore` — 스캔 결과 → 향수 등록 폼 prefill 상태 관리
- `globals.css` — 가격 카드 스켈레톤 스타일 추가

## Test plan

- [ ] 카메라 촬영 및 파일 업로드로 향수 인식 확인
- [ ] 가격 카드 및 스켈레톤 UI 확인
- [ ] 유사 향수 갤러리·네이버 추천 로딩 확인
- [ ] 네트워크 요청 rate limit 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)