### PR TITLE
feat: 스캔 결과 → 향수 등록 폼 자동 입력 연동

### DIFF
--- a/next-server/next.config.js
+++ b/next-server/next.config.js
@@ -70,6 +70,10 @@ const nextConfig = {
           },
           {
             protocol: 'https',
+            hostname: 'shopping-phinf.pstatic.net',
+          },
+          {
+            protocol: 'https',
             hostname: 'mjcong.co.kr',
           },
           {

--- a/next-server/src/app/api/fragrance/analyze/route.ts
+++ b/next-server/src/app/api/fragrance/analyze/route.ts
@@ -1,96 +1,94 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/src/app/lib/session";
+import { analyzeFragranceFromUrl } from "@/src/app/lib/scan/visionAnalyze";
+import { enrichFragranceInfo } from "@/src/app/lib/scan/enrichInfo";
 
-export async function POST(req: NextRequest) {
-    try {
-        const user = await getCurrentUser();
-        if (!user?.id || !user?.email) {
-            return NextResponse.json({ message: '로그인이 필요합니다.' }, { status: 401 });
-        }
+/**
+ * 등록용 향수 이미지 분석 (FormFragrance 에서 호출).
+ *
+ * 옵션 B 패턴 — 스캔 흐름과 통일된 2-stage pipeline:
+ *   1) Vision OCR (gpt-4o → gpt-4o-mini fallback): brand + name 만 추출
+ *      - max_tokens 400 (이전 800) — 응답 토큰 절반, 비용 ↓
+ *      - "identify" 대신 OCR 톤 → refusal 감소
+ *   2) LLM 보강 (gpt-4o-mini, 텍스트만): description + notes
+ *      - 향수 지식 활용 → 정확도 ↑, hallucination 방지 프롬프트
+ *      - 비용 $0.0001 (Vision의 1/50)
+ *   3) slug 자동 생성 (코드, LLM 토큰 0)
+ *
+ * 응답 형식 유지: FragranceAnalysis { isFragrance, brand, name, slug, description, notes }
+ */
 
-        const { imageUrl } = await req.json();
-        if (!imageUrl) {
-            return NextResponse.json({ message: '이미지 URL이 필요합니다.' }, { status: 400 });
-        }
-
-        const apiKey = process.env.OPENAI_API_KEY!;
-
-        const response = await fetch("https://api.openai.com/v1/chat/completions", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify({
-                model: "gpt-4o",
-                messages: [
-                    {
-                        role: "user",
-                        content: [
-                            {
-                                type: "image_url",
-                                image_url: { url: imageUrl },
-                            },
-                            {
-                                type: "text",
-                                text: `You are a perfume expert. Analyze this image and extract fragrance product information.
-
-First, determine if this image is related to a fragrance/perfume product (bottle, package, advertisement, etc.).
-
-Return ONLY a valid JSON object with these exact fields:
-{
-  "isFragrance": true or false (boolean — true only if the image is clearly a fragrance/perfume product),
-  "brand": "Brand/house name visible in the image (empty string if not visible)",
-  "name": "Fragrance name visible in the image (empty string if not visible)",
-  "slug": "URL identifier: combine brand and name in lowercase with underscores, e.g. 'diptyque_philosykos' (empty string if brand or name not visible)",
-  "description": "Write a poetic Korean description of the scent's story and essence based on the bottle design, brand identity, and any visible text. 2-3 sentences. (empty string if nothing can be inferred)",
-  "notes": "Olfactory notes in Korean format: 'TOP: ... HEART: ... BASE: ...' based on brand knowledge. (empty string if not determinable)"
+function makeSlug(brand: string, name: string): string {
+  return `${brand}_${name}`
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣]+/g, "_")
+    .replace(/^_+|_+$/g, "");
 }
 
-If isFragrance is false, set all other fields to empty strings.
-Do NOT include any text or markdown outside the JSON object.`,
-                            },
-                        ],
-                    },
-                ],
-                response_format: { type: "json_object" },
-                max_tokens: 800,
-                temperature: 0.3,
-            }),
-        });
+const EMPTY_RESULT = {
+  isFragrance: false,
+  brand: "",
+  name: "",
+  slug: "",
+  description: "",
+  notes: "",
+};
 
-        if (!response.ok) {
-            const error = await response.json();
-            console.error('[OpenAI Analyze Error]', error);
-
-            if (error?.error?.code === 'invalid_image_format') {
-                return NextResponse.json(
-                    { message: '지원하지 않는 이미지 형식입니다. png, jpeg, gif, webp 형식의 이미지를 업로드해주세요.', code: 'invalid_image_format' },
-                    { status: 400 }
-                );
-            }
-
-            return NextResponse.json({ message: 'AI 분석에 실패했습니다.' }, { status: 500 });
-        }
-
-        const data = await response.json();
-        const content = data.choices?.[0]?.message?.content;
-
-        if (!content) {
-            console.error('[OpenAI Analyze Empty Content Data]', JSON.stringify(data, null, 2));
-            return NextResponse.json({ message: 'AI 응답이 비어있습니다.' }, { status: 500 });
-        }
-
-        try {
-            const parsed = JSON.parse(content);
-            return NextResponse.json({ result: parsed }, { status: 200 });
-        } catch (parseError) {
-            console.error('[OpenAI JSON Parse Error]', parseError);
-            console.error('[OpenAI Raw Content]', content);
-            return NextResponse.json({ message: 'AI 응답 형식 오류입니다.' }, { status: 500 });
-        }
-    } catch (error) {
-        console.error('[Fragrance Analyze Error]', error);
-        return NextResponse.json({ message: 'AI 분석 중 오류가 발생했습니다.' }, { status: 500 });
+export async function POST(req: NextRequest) {
+  try {
+    const user = await getCurrentUser();
+    if (!user?.id || !user?.email) {
+      return NextResponse.json(
+        { message: "로그인이 필요합니다." },
+        { status: 401 },
+      );
     }
+
+    const body = await req.json().catch(() => null);
+    const imageUrl: unknown = body?.imageUrl;
+    if (typeof imageUrl !== "string" || !imageUrl) {
+      return NextResponse.json(
+        { message: "이미지 URL이 필요합니다." },
+        { status: 400 },
+      );
+    }
+
+    // 1단계: Vision OCR (brand + name)
+    const vision = await analyzeFragranceFromUrl(imageUrl);
+
+    if (!vision.isFragrance || !vision.brand || !vision.name) {
+      return NextResponse.json({
+        result: { ...EMPTY_RESULT, isFragrance: vision.isFragrance },
+      });
+    }
+
+    // 2단계: LLM 보강 (description + notes + 영문 slug)
+    const enriched = await enrichFragranceInfo(vision.brand, vision.name);
+
+    // 3단계: slug 결정 — LLM 영문 slug 우선, 없으면 코드 fallback (한글 포함 가능)
+    const slug = enriched.englishSlug || makeSlug(vision.brand, vision.name);
+
+    return NextResponse.json({
+      result: {
+        isFragrance: true,
+        brand: vision.brand,
+        name: vision.name,
+        slug,
+        description: enriched.description,
+        notes: enriched.notes,
+      },
+      _meta: {
+        tokensUsed: vision.tokensUsed + enriched.tokensUsed,
+        enrichConfident: enriched.confident,
+      },
+    });
+  } catch (err) {
+    console.error("[Fragrance analyze] error:", err);
+    const message =
+      err instanceof Error ? err.message : "AI 분석 중 오류가 발생했습니다.";
+    return NextResponse.json(
+      { message, code: "AI_ANALYSIS_FAILED" },
+      { status: 500 },
+    );
+  }
 }

--- a/next-server/src/app/components/FormFragrance.tsx
+++ b/next-server/src/app/components/FormFragrance.tsx
@@ -12,6 +12,7 @@ import toast from "react-hot-toast";
 
 import { createFragrance } from "@/src/app/lib/createFragrance";
 import { updateFragrance } from "@/src/app/lib/updateFragrance";
+import { useScanPrefillStore } from "@/src/app/store/scanPrefillStore";
 import { withToastParams } from "@/src/app/lib/withToastParams";
 import { fragranceDetailKey, prependFragranceCard, upsertFragranceCardById } from "@/src/app/lib/react-query/fragranceCache";
 import { useImageUpload, type PreviewImage } from "@/src/app/lib/useImageUpload";
@@ -69,6 +70,10 @@ const FormFragrance = ({ id, isEdit, initialData }: FormFragranceProps) => {
 
     const [isAnalyzing, setIsAnalyzing] = useState(false);
     const [isValidating, setIsValidating] = useState(false);
+    const [scanPrefilled, setScanPrefilled] = useState(false);
+
+    const scanPrefill = useScanPrefillStore((s) => s.prefill);
+    const clearScanPrefill = useScanPrefillStore((s) => s.clear);
 
     const triggerBrand = useCallback(() => trigger("brand"), [trigger]);
     const triggerName = useCallback(() => trigger("name"), [trigger]);
@@ -187,6 +192,21 @@ const FormFragrance = ({ id, isEdit, initialData }: FormFragranceProps) => {
             initImages(initialData.images);
         }
     }, [initialData, initImages, reset]);
+
+    useEffect(() => {
+        if (isEdit || !scanPrefill) return;
+
+        const { brand, name, description, notes, imageUrl } = scanPrefill;
+        setValue('brand', brand.toUpperCase());
+        setValue('name', name);
+        setValue('description', description);
+        setValue('notes', notes);
+        setFormData((prev) => ({ ...prev, brand, name, description, notes, images: [imageUrl] }));
+        initImages([imageUrl]);
+        setScanPrefilled(true);
+        clearScanPrefill();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const handleFileInputChange = useCallback(
         (e: ChangeEvent<HTMLInputElement>) => {
@@ -396,6 +416,14 @@ const FormFragrance = ({ id, isEdit, initialData }: FormFragranceProps) => {
                 </div>
 
                 <div className="fragrance-form-right gap-12">
+                    {scanPrefilled && !isAnalyzing && (
+                        <div className="flex items-center gap-3 px-5 py-3.5 rounded-2xl bg-[#f1ecfe] dark:bg-[#2d2040]/60 border border-[#c8b4ff40]">
+                            <HiSparkles className="text-[#b094e0] w-4 h-4 shrink-0" />
+                            <p className="text-[0.75rem] tracking-[0.15em] uppercase text-[#5c4a7a] dark:text-[#c8b4ff] font-medium">
+                                스캔 결과에서 자동 입력됐습니다.
+                            </p>
+                        </div>
+                    )}
                     {isAnalyzing && (
                         <div className="flex items-center gap-3 px-5 py-3.5 rounded-2xl bg-[#f1ecfe] dark:bg-[#2d2040]/60 border border-[#c8b4ff40]">
                             <HiSparkles className="text-[#b094e0] w-4 h-4 shrink-0 animate-pulse" />


### PR DESCRIPTION
## Summary

- `FormFragrance`: 스캔 prefill store에서 brand·name·description·notes·imageUrl 자동 입력, "스캔 결과에서 자동 입력됐습니다" 배너 표시
- `fragrance/analyze` route: 스캔과 동일한 Vision OCR 2-stage 파이프라인으로 리팩터 (단일 gpt-4o 호출 → `visionAnalyze` + `enrichFragranceInfo` 분리)
- `next.config.js`: 네이버 쇼핑 이미지 도메인(`shopping-phinf.pstatic.net`) 허용 추가

## Test plan

- [ ] 스캔 결과 페이지 → 향수 등록 폼으로 이동 시 자동 입력 확인
- [ ] "스캔 결과에서 자동 입력됐습니다" 배너 표시 확인
- [ ] 기존 FormFragrance 이미지 분석 기능 정상 동작 확인
- [ ] 네이버 쇼핑 이미지 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)