### PR TITLE
fix: SocketState CancelledError 콘솔 에러 제거

### DIFF
--- a/next-server/src/app/components/SocketState.tsx
+++ b/next-server/src/app/components/SocketState.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useQueryClient } from "@tanstack/react-query";
+import { CancelledError, useQueryClient } from "@tanstack/react-query";
 import useUnreadStore from "@/src/app/hooks/useUnReadStore";
 import { useEffect, useRef, useCallback } from "react";
 import { useRouter, usePathname } from "next/navigation";
@@ -264,6 +264,8 @@ const SocketState = () => {
         staleTime: 30_000,
         gcTime: 5 * 60_000,
       }).catch(err => {
+        // CancelledError는 의도된 query 취소 (cleanup·navigation·strict mode) — silent
+        if (err instanceof CancelledError) return;
         console.error('[SocketState] conversationList 로드 실패:', err);
       });
     }
@@ -436,6 +438,8 @@ const SocketState = () => {
         staleTime: 30_000,
         gcTime: 5 * 60_000,
       }).catch(err => {
+        // CancelledError는 의도된 query 취소 (cleanup·navigation·strict mode) — silent
+        if (err instanceof CancelledError) return;
         console.error('[SocketState] conversationList 로드 실패:', err);
       });
     }


### PR DESCRIPTION
## Summary

- cleanup·navigation·React strict mode에서 의도적으로 발생하는 query 취소를 `CancelledError` 타입으로 구분해 `console.error` 출력 억제
- 실제 오류와 정상적인 query 취소를 분리해 로그 노이즈 제거

## Test plan

- [ ] 페이지 이동 시 콘솔에 `conversationList 로드 실패` 에러가 없는지 확인
- [ ] 실제 네트워크 오류는 여전히 콘솔에 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)